### PR TITLE
Uploaded files associated with Both Lasers Gain of 5

### DIFF
--- a/Batch_E_B_Welch.m
+++ b/Batch_E_B_Welch.m
@@ -1,0 +1,1435 @@
+%This code is for density overlap for single color only
+
+MasterC = 'E:\Batch\5B\Control';
+%MasterC = 'E:\Batch\5B\Extra'; - NOPE
+%MasterC = 'E:\Batch\5B\All';
+%MasterC = 'E:\Batch\5B\Cont';
+
+MasterCS = imageDatastore(MasterC);
+
+%Master Control
+MCR = batchMR(MasterCS);
+MSR = batchR(MasterCS);
+
+MSRrday = diffR2(MSR,MCR);
+%MSRrdiff = (1-(MSRrday(1,:)));
+%MSRrmeanstd = sumR(MSRrdiff);
+
+Mmean = MSRrday(:,1);
+Mstd2pos = MSRrday(:,2);
+Mstd3pos = MSRrday(:,3);
+%Mstd2neg = MSRrdiff(:,2);
+%Mstd3neg = MSRrdiff(:,3);
+
+
+%Copper - Trial 1
+CuC = 'E:\Batch\5B\T1Cu\0';
+Cu1 = 'E:\Batch\5B\T1Cu\1';
+Cu2 = 'E:\Batch\5B\T1Cu\2';
+Cu3 = 'E:\Batch\5B\T1Cu\3';
+Cu4 = 'E:\Batch\5B\T1Cu\4';
+Cu5 = 'E:\Batch\5B\T1Cu\5';
+Cu6 = 'E:\Batch\5B\T1Cu\6';
+Cu7 = 'E:\Batch\5B\T1Cu\7';
+CuCS = imageDatastore(CuC);
+Cu1S = imageDatastore(Cu1);
+Cu2S = imageDatastore(Cu2);
+Cu3S = imageDatastore(Cu3);
+Cu4S = imageDatastore(Cu4);
+Cu5S = imageDatastore(Cu5);
+Cu6S = imageDatastore(Cu6);
+Cu7S = imageDatastore(Cu7);
+
+Cu0R = batchR(CuCS);
+Cu1R = batchR(Cu1S);
+Cu2R = batchR(Cu2S);
+Cu3R = batchR(Cu3S);
+Cu4R = batchR(Cu4S);
+Cu5R = batchR(Cu5S);
+Cu6R = batchR(Cu6S);
+Cu7R = batchR(Cu7S);
+
+rday0 = diffR2(Cu0R,MSR);
+rday1 = diffR2(Cu1R,MSR);
+rday2 = diffR2(Cu2R,MSR);
+rday3 = diffR2(Cu3R,MSR);
+rday4 = diffR2(Cu4R,MSR);
+rday5 = diffR2(Cu5R,MSR);
+rday6 = diffR2(Cu6R,MSR);
+rday7 = diffR2(Cu7R,MSR);
+
+rmean = [rday0(:,1); rday1(:,1); rday2(:,1); rday3(:,1); rday4(:,1); rday5(:,1); rday6(:,1); rday7(:,1)];
+%rstd2 = [rmeanstd0(:,2); rmeanstd1(:,2); rmeanstd2(:,2); rmeanstd3(:,2); rmeanstd4(:,2); rmeanstd5(:,2); rmeanstd6(:,2); rmeanstd7(:,2)];
+%rstd3 = [rmeanstd0(:,3); rmeanstd1(:,3); rmeanstd2(:,3); rmeanstd3(:,3); rmeanstd4(:,3); rmeanstd5(:,3); rmeanstd6(:,3); rmeanstd7(:,3)];
+
+%Zinc - Trial 2
+ZnC = 'E:\Batch\5B\T2Zn\0';
+Zn1 = 'E:\Batch\5B\T2Zn\1';
+Zn2 = 'E:\Batch\5B\T2Zn\2';
+Zn3 = 'E:\Batch\5B\T2Zn\3';
+Zn4 = 'E:\Batch\5B\T2Zn\4';
+Zn5 = 'E:\Batch\5B\T2Zn\5';
+Zn6 = 'E:\Batch\5B\T2Zn\6';
+Zn7 = 'E:\Batch\5B\T2Zn\7';
+ZnCS = imageDatastore(ZnC);
+Zn1S = imageDatastore(Zn1);
+Zn2S = imageDatastore(Zn2);
+Zn3S = imageDatastore(Zn3);
+Zn4S = imageDatastore(Zn4);
+Zn5S = imageDatastore(Zn5);
+Zn6S = imageDatastore(Zn6);
+Zn7S = imageDatastore(Zn7);
+
+Zn0R = batchR(ZnCS);
+Zn1R = batchR(Zn1S);
+Zn2R = batchR(Zn2S);
+Zn3R = batchR(Zn3S);
+Zn4R = batchR(Zn4S);
+Zn5R = batchR(Zn5S);
+Zn6R = batchR(Zn6S);
+Zn7R = batchR(Zn7S);
+
+zrday0 = diffR2(Zn0R,MSR);
+zrday1 = diffR2(Zn1R,MSR);
+zrday2 = diffR2(Zn2R,MSR);
+zrday3 = diffR2(Zn3R,MSR);
+zrday4 = diffR2(Zn4R,MSR);
+zrday5 = diffR2(Zn5R,MSR);
+zrday6 = diffR2(Zn6R,MSR);
+zrday7 = diffR2(Zn7R,MSR);
+
+zrmean = [zrday0(:,1); zrday1(:,1); zrday2(:,1); zrday3(:,1); zrday4(:,1); zrday5(:,1); zrday6(:,1); zrday7(:,1)];
+
+%Lead - Trial 3
+PbC = 'E:\Batch\5B\T3Pb\0';
+Pb1 = 'E:\Batch\5B\T3Pb\1';
+Pb2 = 'E:\Batch\5B\T3Pb\2';
+Pb3 = 'E:\Batch\5B\T3Pb\3';
+Pb4 = 'E:\Batch\5B\T3Pb\4';
+Pb5 = 'E:\Batch\5B\T3Pb\5';
+Pb6 = 'E:\Batch\5B\T3Pb\6';
+Pb7 = 'E:\Batch\5B\T3Pb\7';
+PbCS = imageDatastore(PbC);
+Pb1S = imageDatastore(Pb1);
+Pb2S = imageDatastore(Pb2);
+Pb3S = imageDatastore(Pb3);
+Pb4S = imageDatastore(Pb4);
+Pb5S = imageDatastore(Pb5);
+Pb6S = imageDatastore(Pb6);
+Pb7S = imageDatastore(Pb7);
+Pb0R = batchR(PbCS);
+Pb1R = batchR(Pb1S);
+Pb2R = batchR(Pb2S);
+Pb3R = batchR(Pb3S);
+Pb4R = batchR(Pb4S);
+Pb5R = batchR(Pb5S);
+Pb6R = batchR(Pb6S);
+Pb7R = batchR(Pb7S);
+
+prday0 = diffR2(Pb0R,MSR);
+prday1 = diffR2(Pb1R,MSR);
+prday2 = diffR2(Pb2R,MSR);
+prday3 = diffR2(Pb3R,MSR);
+prday4 = diffR2(Pb4R,MSR);
+prday5 = diffR2(Pb5R,MSR);
+prday6 = diffR2(Pb6R,MSR);
+prday7 = diffR2(Pb7R,MSR);
+
+prmean = [prday0(:,1); prday1(:,1); prday2(:,1); prday3(:,1); prday4(:,1); prday5(:,1); prday6(:,1); prday7(:,1)];
+
+%Mix - Trial 4
+MC = 'E:\Batch\5B\T4Mix\0';
+M1 = 'E:\Batch\5B\T4Mix\1';
+M2 = 'E:\Batch\5B\T4Mix\2';
+M3 = 'E:\Batch\5B\T4Mix\3';
+M4 = 'E:\Batch\5B\T4Mix\4';
+M5 = 'E:\Batch\5B\T4Mix\5';
+M6 = 'E:\Batch\5B\T4Mix\6';
+M7 = 'E:\Batch\5B\T4Mix\7';
+MCS = imageDatastore(MC);
+M1S = imageDatastore(M1);
+M2S = imageDatastore(M2);
+M3S = imageDatastore(M3);
+M4S = imageDatastore(M4);
+M5S = imageDatastore(M5);
+M6S = imageDatastore(M6);
+M7S = imageDatastore(M7);
+M0R = batchR(MCS);
+M1R = batchR(M1S);
+M2R = batchR(M2S);
+M3R = batchR(M3S);
+M4R = batchR(M4S);
+M5R = batchR(M5S);
+M6R = batchR(M6S);
+M7R = batchR(M7S);
+
+mrday0 = diffR2(M0R,MSR);
+mrday1 = diffR2(M1R,MSR);
+mrday2 = diffR2(M2R,MSR);
+mrday3 = diffR2(M3R,MSR);
+mrday4 = diffR2(M4R,MSR);
+mrday5 = diffR2(M5R,MSR);
+mrday6 = diffR2(M6R,MSR);
+mrday7 = diffR2(M7R,MSR);
+
+mrmean = [mrday0(:,1); mrday1(:,1); mrday2(:,1); mrday3(:,1); mrday4(:,1); mrday5(:,1); mrday6(:,1); mrday7(:,1)];
+
+%Control for comparison
+CC = 'E:\Batch\5B\T5Con\0';
+C1 = 'E:\Batch\5B\T5Con\1';
+C2 = 'E:\Batch\5B\T5Con\2';
+C3 = 'E:\Batch\5B\T5Con\3';
+C4 = 'E:\Batch\5B\T5Con\4';
+C5 = 'E:\Batch\5B\T5Con\5';
+C6 = 'E:\Batch\5B\T5Con\6';
+C7 = 'E:\Batch\5B\T5Con\7';
+CCS = imageDatastore(CC);
+C1S = imageDatastore(C1);
+C2S = imageDatastore(C2);
+C3S = imageDatastore(C3);
+C4S = imageDatastore(C4);
+C5S = imageDatastore(C5);
+C6S = imageDatastore(C6);
+C7S = imageDatastore(C7);
+C0R = batchR(CCS);
+C1R = batchR(C1S);
+C2R = batchR(C2S);
+C3R = batchR(C3S);
+C4R = batchR(C4S);
+C5R = batchR(C5S);
+C6R = batchR(C6S);
+C7R = batchR(C7S);
+
+crday0 = diffR2(C0R,MSR);
+crday1 = diffR2(C1R,MSR);
+crday2 = diffR2(C2R,MSR);
+crday3 = diffR2(C3R,MSR);
+crday4 = diffR2(C4R,MSR);
+crday5 = diffR2(C5R,MSR);
+crday6 = diffR2(C6R,MSR);
+crday7 = diffR2(C7R,MSR);
+
+crmean = [crday0(:,1); crday1(:,1); crday2(:,1); crday3(:,1); crday4(:,1); crday5(:,1); crday6(:,1); crday7(:,1)];
+
+ContM = sum(crmean)/8
+Contvar = sum((crmean - ContM).^2)./(7);
+Contstd = sqrt(Contvar);
+Contstd2 = ContM + (2.*Contstd')
+Contstd3 = ContM + (3.*Contstd')
+
+%Wet - Trial 6
+WC = 'E:\Batch\5B\T6Wet\0';
+W1 = 'E:\Batch\5B\T6Wet\1';
+W2 = 'E:\Batch\5B\T6Wet\2';
+W3 = 'E:\Batch\5B\T6Wet\3';
+W4 = 'E:\Batch\5B\T6Wet\4';
+W5 = 'E:\Batch\5B\T6Wet\5';
+W6 = 'E:\Batch\5B\T6Wet\6';
+W7 = 'E:\Batch\5B\T6Wet\7';
+WCS = imageDatastore(WC);
+W1S = imageDatastore(W1);
+W2S = imageDatastore(W2);
+W3S = imageDatastore(W3);
+W4S = imageDatastore(W4);
+W5S = imageDatastore(W5);
+W6S = imageDatastore(W6);
+W7S = imageDatastore(W7);
+W0R = batchR(WCS);
+W1R = batchR(W1S);
+W2R = batchR(W2S);
+W3R = batchR(W3S);
+W4R = batchR(W4S);
+W5R = batchR(W5S);
+W6R = batchR(W6S);
+W7R = batchR(W7S);
+
+wrday0 = diffR2(W0R,MSR);
+wrday1 = diffR2(W1R,MSR);
+wrday2 = diffR2(W2R,MSR);
+wrday3 = diffR2(W3R,MSR);
+wrday4 = diffR2(W4R,MSR);
+wrday5 = diffR2(W5R,MSR);
+wrday6 = diffR2(W6R,MSR);
+wrday7 = diffR2(W7R,MSR);
+
+wrmean = [wrday0(:,1); wrday1(:,1); wrday2(:,1); wrday3(:,1); wrday4(:,1); wrday5(:,1); wrday6(:,1); wrday7(:,1)];
+
+%Dry - Trial 7
+DC = 'E:\Batch\5B\T7Dry\0';
+D1 = 'E:\Batch\5B\T7Dry\1';
+D2 = 'E:\Batch\5B\T7Dry\2';
+D3 = 'E:\Batch\5B\T7Dry\3';
+D4 = 'E:\Batch\5B\T7Dry\4';
+D5 = 'E:\Batch\5B\T7Dry\5';
+D6 = 'E:\Batch\5B\T7Dry\6';
+D7 = 'E:\Batch\5B\T7Dry\7';
+DCS = imageDatastore(DC);
+D1S = imageDatastore(D1);
+D2S = imageDatastore(D2);
+D3S = imageDatastore(D3);
+D4S = imageDatastore(D4);
+D5S = imageDatastore(D5);
+D6S = imageDatastore(D6);
+D7S = imageDatastore(D7);
+D0R = batchR(DCS);
+D1R = batchR(D1S);
+D2R = batchR(D2S);
+D3R = batchR(D3S);
+D4R = batchR(D4S);
+D5R = batchR(D5S);
+D6R = batchR(D6S);
+D7R = batchR(D7S);
+
+drday0 = diffR2(D0R,MSR);
+drday1 = diffR2(D1R,MSR);
+drday2 = diffR2(D2R,MSR);
+drday3 = diffR2(D3R,MSR);
+drday4 = diffR2(D4R,MSR);
+drday5 = diffR2(D5R,MSR);
+drday6 = diffR2(D6R,MSR);
+drday7 = diffR2(D7R,MSR);
+
+drmean = [drday0(:,1); drday1(:,1); drday2(:,1); drday3(:,1); drday4(:,1); drday5(:,1); drday6(:,1); drday7(:,1)];
+
+%Nutrients - Trial 8
+NC = 'E:\Batch\5B\T8Nut\0';
+N1 = 'E:\Batch\5B\T8Nut\1';
+N2 = 'E:\Batch\5B\T8Nut\2';
+N3 = 'E:\Batch\5B\T8Nut\3';
+N4 = 'E:\Batch\5B\T8Nut\4';
+N5 = 'E:\Batch\5B\T8Nut\5';
+N6 = 'E:\Batch\5B\T8Nut\6';
+N7 = 'E:\Batch\5B\T8Nut\7';
+NCS = imageDatastore(NC);
+N1S = imageDatastore(N1);
+N2S = imageDatastore(N2);
+N3S = imageDatastore(N3);
+N4S = imageDatastore(N4);
+N5S = imageDatastore(N5);
+N6S = imageDatastore(N6);
+N7S = imageDatastore(N7);
+N0R = batchR(NCS);
+N1R = batchR(N1S);
+N2R = batchR(N2S);
+N3R = batchR(N3S);
+N4R = batchR(N4S);
+N5R = batchR(N5S);
+N6R = batchR(N6S);
+N7R = batchR(N7S);
+
+nrday0 = diffR2(N0R,MSR);
+nrday1 = diffR2(N1R,MSR);
+nrday2 = diffR2(N2R,MSR);
+nrday3 = diffR2(N3R,MSR);
+nrday4 = diffR2(N4R,MSR);
+nrday5 = diffR2(N5R,MSR);
+nrday6 = diffR2(N6R,MSR);
+nrday7 = diffR2(N7R,MSR);
+
+nrmean = [nrday0(:,1); nrday1(:,1); nrday2(:,1); nrday3(:,1); nrday4(:,1); nrday5(:,1); nrday6(:,1); nrday7(:,1)];
+
+%Long - Trial 9
+LC = 'E:\Batch\5B\T9Long\0';
+L1 = 'E:\Batch\5B\T9Long\1';
+L2 = 'E:\Batch\5B\T9Long\2';
+L3 = 'E:\Batch\5B\T9Long\3';
+L4 = 'E:\Batch\5B\T9Long\4';
+L5 = 'E:\Batch\5B\T9Long\5';
+L6 = 'E:\Batch\5B\T9Long\6';
+L7 = 'E:\Batch\5B\T9Long\7';
+LCS = imageDatastore(LC);
+L1S = imageDatastore(L1);
+L2S = imageDatastore(L2);
+L3S = imageDatastore(L3);
+L4S = imageDatastore(L4);
+L5S = imageDatastore(L5);
+L6S = imageDatastore(L6);
+L7S = imageDatastore(L7);
+L0R = batchR(LCS);
+L1R = batchR(L1S);
+L2R = batchR(L2S);
+L3R = batchR(L3S);
+L4R = batchR(L4S);
+L5R = batchR(L5S);
+L6R = batchR(L6S);
+L7R = batchR(L7S);
+
+lrday0 = diffR2(L0R,MSR);
+lrday1 = diffR2(L1R,MSR);
+lrday2 = diffR2(L2R,MSR);
+lrday3 = diffR2(L3R,MSR);
+lrday4 = diffR2(L4R,MSR);
+lrday5 = diffR2(L5R,MSR);
+lrday6 = diffR2(L6R,MSR);
+lrday7 = diffR2(L7R,MSR);
+
+lrmean = [lrday0(:,1); lrday1(:,1); lrday2(:,1); lrday3(:,1); lrday4(:,1); lrday5(:,1); lrday6(:,1); lrday7(:,1)];
+
+%Short - Trial 10
+SC = 'E:\Batch\5B\T10Shrt\0';
+S1 = 'E:\Batch\5B\T10Shrt\1';
+S2 = 'E:\Batch\5B\T10Shrt\2';
+S3 = 'E:\Batch\5B\T10Shrt\3';
+S4 = 'E:\Batch\5B\T10Shrt\4';
+S5 = 'E:\Batch\5B\T10Shrt\5';
+S6 = 'E:\Batch\5B\T10Shrt\6';
+S7 = 'E:\Batch\5B\T10Shrt\7';
+SCS = imageDatastore(SC);
+S1S = imageDatastore(S1);
+S2S = imageDatastore(S2);
+S3S = imageDatastore(S3);
+S4S = imageDatastore(S4);
+S5S = imageDatastore(S5);
+S6S = imageDatastore(S6);
+S7S = imageDatastore(S7);
+S0R = batchR(SCS);
+S1R = batchR(S1S);
+S2R = batchR(S2S);
+S3R = batchR(S3S);
+S4R = batchR(S4S);
+S5R = batchR(S5S);
+S6R = batchR(S6S);
+S7R = batchR(S7S);
+
+srday0 = diffR2(S0R,MSR);
+srday1 = diffR2(S1R,MSR);
+srday2 = diffR2(S2R,MSR);
+srday3 = diffR2(S3R,MSR);
+srday4 = diffR2(S4R,MSR);
+srday5 = diffR2(S5R,MSR);
+srday6 = diffR2(S6R,MSR);
+srday7 = diffR2(S7R,MSR);
+
+srmean = [srday0(:,1); srday1(:,1); srday2(:,1); srday3(:,1); srday4(:,1); srday5(:,1); srday6(:,1); srday7(:,1)];
+
+%Dark - Trial 11
+AC = 'E:\Batch\5B\T11Dark\0';
+A1 = 'E:\Batch\5B\T11Dark\1';
+A2 = 'E:\Batch\5B\T11Dark\2';
+A3 = 'E:\Batch\5B\T11Dark\3';
+A4 = 'E:\Batch\5B\T11Dark\4';
+A5 = 'E:\Batch\5B\T11Dark\5';
+A6 = 'E:\Batch\5B\T11Dark\6';
+A7 = 'E:\Batch\5B\T11Dark\7';
+ACS = imageDatastore(AC);
+A1S = imageDatastore(A1);
+A2S = imageDatastore(A2);
+A3S = imageDatastore(A3);
+A4S = imageDatastore(A4);
+A5S = imageDatastore(A5);
+A6S = imageDatastore(A6);
+A7S = imageDatastore(A7);
+A0R = batchR(ACS);
+A1R = batchR(A1S);
+A2R = batchR(A2S);
+A3R = batchR(A3S);
+A4R = batchR(A4S);
+A5R = batchR(A5S);
+A6R = batchR(A6S);
+A7R = batchR(A7S);
+
+arday0 = diffR2(A0R,MSR);
+arday1 = diffR2(A1R,MSR);
+arday2 = diffR2(A2R,MSR);
+arday3 = diffR2(A3R,MSR);
+arday4 = diffR2(A4R,MSR);
+arday5 = diffR2(A5R,MSR);
+arday6 = diffR2(A6R,MSR);
+arday7 = diffR2(A7R,MSR);
+
+armean = [arday0(:,1); arday1(:,1); arday2(:,1); arday3(:,1); arday4(:,1); arday5(:,1); arday6(:,1); arday7(:,1)];
+
+%WELCH
+CuWr0 = Welch(crday0(:,1), rday0(:,1), crday0(:,5), rday0(:,5));
+CuWr1 = Welch(crday1(:,1), rday1(:,1), crday1(:,5), rday1(:,5));
+CuWr2 = Welch(crday2(:,1), rday2(:,1), crday2(:,5), rday2(:,5));
+CuWr3 = Welch(crday3(:,1), rday3(:,1), crday3(:,5), rday3(:,5));
+CuWr4 = Welch(crday4(:,1), rday4(:,1), crday4(:,5), rday4(:,5));
+CuWr5 = Welch(crday5(:,1), rday5(:,1), crday5(:,5), rday5(:,5));
+CuWr6 = Welch(crday6(:,1), rday6(:,1), crday6(:,5), rday6(:,5));
+CuWr7 = Welch(crday7(:,1), rday7(:,1), crday7(:,5), rday7(:,5));
+
+ZnWr0 = Welch(crday0(:,1), zrday0(:,1), crday0(:,5), zrday0(:,5));
+ZnWr1 = Welch(crday1(:,1), zrday1(:,1), crday1(:,5), zrday1(:,5));
+ZnWr2 = Welch(crday2(:,1), zrday2(:,1), crday2(:,5), zrday2(:,5));
+ZnWr3 = Welch(crday3(:,1), zrday3(:,1), crday3(:,5), zrday3(:,5));
+ZnWr4 = Welch(crday4(:,1), zrday4(:,1), crday4(:,5), zrday4(:,5));
+ZnWr5 = Welch(crday5(:,1), zrday5(:,1), crday5(:,5), zrday5(:,5));
+ZnWr6 = Welch(crday6(:,1), zrday6(:,1), crday6(:,5), zrday6(:,5));
+ZnWr7 = Welch(crday7(:,1), zrday7(:,1), crday7(:,5), zrday7(:,5));
+
+PbWr0 = Welch(crday0(:,1), prday0(:,1), crday0(:,5), prday0(:,5));
+PbWr1 = Welch(crday1(:,1), prday1(:,1), crday1(:,5), prday1(:,5));
+PbWr2 = Welch(crday2(:,1), prday2(:,1), crday2(:,5), prday2(:,5));
+PbWr3 = Welch(crday3(:,1), prday3(:,1), crday3(:,5), prday3(:,5));
+PbWr4 = Welch(crday4(:,1), prday4(:,1), crday4(:,5), prday4(:,5));
+PbWr5 = Welch(crday5(:,1), prday5(:,1), crday5(:,5), prday5(:,5));
+PbWr6 = Welch(crday6(:,1), prday6(:,1), crday6(:,5), prday6(:,5));
+PbWr7 = Welch(crday7(:,1), prday7(:,1), crday7(:,5), prday7(:,5));
+
+MxWr0 = Welch(crday0(:,1), mrday0(:,1), crday0(:,5), mrday0(:,5));
+MxWr1 = Welch(crday1(:,1), mrday1(:,1), crday1(:,5), mrday1(:,5));
+MxWr2 = Welch(crday2(:,1), mrday2(:,1), crday2(:,5), mrday2(:,5));
+MxWr3 = Welch(crday3(:,1), mrday3(:,1), crday3(:,5), mrday3(:,5));
+MxWr4 = Welch(crday4(:,1), mrday4(:,1), crday4(:,5), mrday4(:,5));
+MxWr5 = Welch(crday5(:,1), mrday5(:,1), crday5(:,5), mrday5(:,5));
+MxWr6 = Welch(crday6(:,1), mrday6(:,1), crday6(:,5), mrday6(:,5));
+MxWr7 = Welch(crday7(:,1), mrday7(:,1), crday7(:,5), mrday7(:,5));
+
+WWr0 = Welch(crday0(:,1), wrday0(:,1), crday0(:,5), wrday0(:,5));
+WWr1 = Welch(crday1(:,1), wrday1(:,1), crday1(:,5), wrday1(:,5));
+WWr2 = Welch(crday2(:,1), wrday2(:,1), crday2(:,5), wrday2(:,5));
+WWr3 = Welch(crday3(:,1), wrday3(:,1), crday3(:,5), wrday3(:,5));
+WWr4 = Welch(crday4(:,1), wrday4(:,1), crday4(:,5), wrday4(:,5));
+WWr5 = Welch(crday5(:,1), wrday5(:,1), crday5(:,5), wrday5(:,5));
+WWr6 = Welch(crday6(:,1), wrday6(:,1), crday6(:,5), wrday6(:,5));
+WWr7 = Welch(crday7(:,1), wrday7(:,1), crday7(:,5), wrday7(:,5));
+
+DWr0 = Welch(crday0(:,1), drday0(:,1), crday0(:,5), drday0(:,5));
+DWr1 = Welch(crday1(:,1), drday1(:,1), crday1(:,5), drday1(:,5));
+DWr2 = Welch(crday2(:,1), drday2(:,1), crday2(:,5), drday2(:,5));
+DWr3 = Welch(crday3(:,1), drday3(:,1), crday3(:,5), drday3(:,5));
+DWr4 = Welch(crday4(:,1), drday4(:,1), crday4(:,5), drday4(:,5));
+DWr5 = Welch(crday5(:,1), drday5(:,1), crday5(:,5), drday5(:,5));
+DWr6 = Welch(crday6(:,1), drday6(:,1), crday6(:,5), drday6(:,5));
+DWr7 = Welch(crday7(:,1), drday7(:,1), crday7(:,5), drday7(:,5));
+
+NWr0 = Welch(crday0(:,1), nrday0(:,1), crday0(:,5), nrday0(:,5));
+NWr1 = Welch(crday1(:,1), nrday1(:,1), crday1(:,5), nrday1(:,5));
+NWr2 = Welch(crday2(:,1), nrday2(:,1), crday2(:,5), nrday2(:,5));
+NWr3 = Welch(crday3(:,1), nrday3(:,1), crday3(:,5), nrday3(:,5));
+NWr4 = Welch(crday4(:,1), nrday4(:,1), crday4(:,5), nrday4(:,5));
+NWr5 = Welch(crday5(:,1), nrday5(:,1), crday5(:,5), nrday5(:,5));
+NWr6 = Welch(crday6(:,1), nrday6(:,1), crday6(:,5), nrday6(:,5));
+NWr7 = Welch(crday7(:,1), nrday7(:,1), crday7(:,5), nrday7(:,5));
+
+LWr0 = Welch(crday0(:,1), lrday0(:,1), crday0(:,5), lrday0(:,5));
+LWr1 = Welch(crday1(:,1), lrday1(:,1), crday1(:,5), lrday1(:,5));
+LWr2 = Welch(crday2(:,1), lrday2(:,1), crday2(:,5), lrday2(:,5));
+LWr3 = Welch(crday3(:,1), lrday3(:,1), crday3(:,5), lrday3(:,5));
+LWr4 = Welch(crday4(:,1), lrday4(:,1), crday4(:,5), lrday4(:,5));
+LWr5 = Welch(crday5(:,1), lrday5(:,1), crday5(:,5), lrday5(:,5));
+LWr6 = Welch(crday6(:,1), lrday6(:,1), crday6(:,5), lrday6(:,5));
+LWr7 = Welch(crday7(:,1), lrday7(:,1), crday7(:,5), lrday7(:,5));
+
+SWr0 = Welch(crday0(:,1), srday0(:,1), crday0(:,5), srday0(:,5));
+SWr1 = Welch(crday1(:,1), srday1(:,1), crday1(:,5), srday1(:,5));
+SWr2 = Welch(crday2(:,1), srday2(:,1), crday2(:,5), srday2(:,5));
+SWr3 = Welch(crday3(:,1), srday3(:,1), crday3(:,5), srday3(:,5));
+SWr4 = Welch(crday4(:,1), srday4(:,1), crday4(:,5), srday4(:,5));
+SWr5 = Welch(crday5(:,1), srday5(:,1), crday5(:,5), srday5(:,5));
+SWr6 = Welch(crday6(:,1), srday6(:,1), crday6(:,5), srday6(:,5));
+SWr7 = Welch(crday7(:,1), srday7(:,1), crday7(:,5), srday7(:,5));
+
+AWr0 = Welch(crday0(:,1), arday0(:,1), crday0(:,5), arday0(:,5));
+AWr1 = Welch(crday1(:,1), arday1(:,1), crday1(:,5), arday1(:,5));
+AWr2 = Welch(crday2(:,1), arday2(:,1), crday2(:,5), arday2(:,5));
+AWr3 = Welch(crday3(:,1), arday3(:,1), crday3(:,5), arday3(:,5));
+AWr4 = Welch(crday4(:,1), arday4(:,1), crday4(:,5), arday4(:,5));
+AWr5 = Welch(crday5(:,1), arday5(:,1), crday5(:,5), arday5(:,5));
+AWr6 = Welch(crday6(:,1), arday6(:,1), crday6(:,5), arday6(:,5));
+AWr7 = Welch(crday7(:,1), arday7(:,1), crday7(:,5), arday7(:,5));
+
+%metal only
+x = (0:7);
+figure;
+plot(x,rmean,'LineWidth',2);
+hold on
+plot(x,zrmean,'LineWidth',2);
+plot(x,prmean,'LineWidth',2);
+plot(x,mrmean,'LineWidth',2);
+%plot(x,crmean);
+%yline(Mmean,'k');
+%yline(Mstd2pos,'k--');
+%yline(Mstd3pos,'k:');
+yline(ContM,'k','LineWidth',2);
+yline(Contstd2,'k--','LineWidth',2);
+yline(Contstd3,'k:','LineWidth',2);
+legend('Cu','Zn','Pb','Mix','Mean','2\sigma','3\sigma');
+set(gca,'fontname','arial','fontsize',18,'fontweight','bold');
+xlabel('Time(days)')
+%ylabel('Intersection Difference (Density)')
+axis([0 7 0 .65]);
+hold off
+
+%environmental only
+x = (0:7);
+figure;
+plot(x,wrmean,'LineWidth',2);
+hold on
+plot(x,drmean,'LineWidth',2);
+plot(x,nrmean,'LineWidth',2);
+yline(ContM,'k','LineWidth',2);
+yline(Contstd2,'k--','LineWidth',2);
+yline(Contstd3,'k:','LineWidth',2);
+legend('Wet','Dry','Nutr.','Mean','2\sigma','3\sigma');
+set(gca,'fontname','arial','fontsize',18,'fontweight','bold');
+xlabel('Time(days)')
+%ylabel('Intersection Difference (Density)')
+axis([0 7 0 .65]);
+hold off
+
+%photoperiod only
+x = (0:7);
+figure;
+plot(x,lrmean,'LineWidth',2);
+hold on
+plot(x,srmean,'LineWidth',2);
+plot(x,armean,'LineWidth',2);
+yline(ContM,'k','LineWidth',2);
+yline(Contstd2,'k--','LineWidth',2);
+yline(Contstd3,'k:','LineWidth',2);
+legend('Long','Short','Dark','Mean','2\sigma','3\sigma');
+set(gca,'fontname','arial','fontsize',18,'fontweight','bold');
+xlabel('Time(days)')
+%ylabel('Intersection Difference (Density)')
+axis([0 7 0 .65]);
+hold off
+
+
+%GREEN
+MasterC = 'E:\Batch\5B\Control';
+%MasterC = 'E:\Batch\5B\Extra'; - NOPE
+%MasterC = 'E:\Batch\5B\All';
+%MasterC = 'E:\Batch\5B\Cont';
+MasterCS = imageDatastore(MasterC);
+
+%Master Control
+MCG = batchMG(MasterCS);
+MSG = batchG(MasterCS);
+
+MSGrday = diffR2(MSG,MCG);
+
+gMmean = MSRrday(:,1);
+gMstd2pos = MSRrday(:,2);
+gMstd3pos = MSRrday(:,3);
+
+%Copper - Trial 1
+Cu0G = batchG(CuCS);
+Cu1G = batchG(Cu1S);
+Cu2G = batchG(Cu2S);
+Cu3G = batchG(Cu3S);
+Cu4G = batchG(Cu4S);
+Cu5G = batchG(Cu5S);
+Cu6G = batchG(Cu6S);
+Cu7G = batchG(Cu7S);
+
+gday0 = diffR2(Cu0G,MSG);
+gday1 = diffR2(Cu1G,MSG);
+gday2 = diffR2(Cu2G,MSG);
+gday3 = diffR2(Cu3G,MSG);
+gday4 = diffR2(Cu4G,MSG);
+gday5 = diffR2(Cu5G,MSG);
+gday6 = diffR2(Cu6G,MSG);
+gday7 = diffR2(Cu7G,MSG);
+
+
+gmean = [gday0(:,1); gday1(:,1); gday2(:,1); gday3(:,1); gday4(:,1); gday5(:,1); gday6(:,1); gday7(:,1)];
+
+%Zinc - Trial 2
+Zn0G = batchG(ZnCS);
+Zn1G = batchG(Zn1S);
+Zn2G = batchG(Zn2S);
+Zn3G = batchG(Zn3S);
+Zn4G = batchG(Zn4S);
+Zn5G = batchG(Zn5S);
+Zn6G = batchG(Zn6S);
+Zn7G = batchG(Zn7S);
+
+zgday0 = diffR2(Zn0G,MSG);
+zgday1 = diffR2(Zn1G,MSG);
+zgday2 = diffR2(Zn2G,MSG);
+zgday3 = diffR2(Zn3G,MSG);
+zgday4 = diffR2(Zn4G,MSG);
+zgday5 = diffR2(Zn5G,MSG);
+zgday6 = diffR2(Zn6G,MSG);
+zgday7 = diffR2(Zn7G,MSG);
+
+zgmean = [zgday0(:,1); zgday1(:,1); zgday2(:,1); zgday3(:,1); zgday4(:,1); zgday5(:,1); zgday6(:,1); zgday7(:,1)];
+
+%Lead - Trial 3
+Pb0G = batchG(PbCS);
+Pb1G = batchG(Pb1S);
+Pb2G = batchG(Pb2S);
+Pb3G = batchG(Pb3S);
+Pb4G = batchG(Pb4S);
+Pb5G = batchG(Pb5S);
+Pb6G = batchG(Pb6S);
+Pb7G = batchG(Pb7S);
+
+pgday0 = diffR2(Pb0G,MSG);
+pgday1 = diffR2(Pb1G,MSG);
+pgday2 = diffR2(Pb2G,MSG);
+pgday3 = diffR2(Pb3G,MSG);
+pgday4 = diffR2(Pb4G,MSG);
+pgday5 = diffR2(Pb5G,MSG);
+pgday6 = diffR2(Pb6G,MSG);
+pgday7 = diffR2(Pb7G,MSG);
+
+pgmean = [pgday0(:,1); pgday1(:,1); pgday2(:,1); pgday3(:,1); pgday4(:,1); pgday5(:,1); pgday6(:,1); pgday7(:,1)];
+
+%Mix - Trial 4
+M0G = batchG(MCS);
+M1G = batchG(M1S);
+M2G = batchG(M2S);
+M3G = batchG(M3S);
+M4G = batchG(M4S);
+M5G = batchG(M5S);
+M6G = batchG(M6S);
+M7G = batchG(M7S);
+
+mgday0 = diffR2(M0G,MSG);
+mgday1 = diffR2(M1G,MSG);
+mgday2 = diffR2(M2G,MSG);
+mgday3 = diffR2(M3G,MSG);
+mgday4 = diffR2(M4G,MSG);
+mgday5 = diffR2(M5G,MSG);
+mgday6 = diffR2(M6G,MSG);
+mgday7 = diffR2(M7G,MSG);
+
+mgmean = [mgday0(:,1); mgday1(:,1); mgday2(:,1); mgday3(:,1); mgday4(:,1); mgday5(:,1); mgday6(:,1); mgday7(:,1)];
+
+%Control for comparison
+C0G = batchG(CCS);
+C1G = batchG(C1S);
+C2G = batchG(C2S);
+C3G = batchG(C3S);
+C4G = batchG(C4S);
+C5G = batchG(C5S);
+C6G = batchG(C6S);
+C7G = batchG(C7S);
+
+cgday0 = diffR2(C0G,MSG);
+cgday1 = diffR2(C1G,MSG);
+cgday2 = diffR2(C2G,MSG);
+cgday3 = diffR2(C3G,MSG);
+cgday4 = diffR2(C4G,MSG);
+cgday5 = diffR2(C5G,MSG);
+cgday6 = diffR2(C6G,MSG);
+cgday7 = diffR2(C7G,MSG);
+
+cgmean = [cgday0(:,1); cgday1(:,1); cgday2(:,1); cgday3(:,1); cgday4(:,1); cgday5(:,1); cgday6(:,1); cgday7(:,1)];
+
+ContMg = sum(cgmean)/8
+Contvarg = sum((cgmean - ContMg).^2)./(7);
+Contstdg = sqrt(Contvarg);
+Contstd2g = ContMg + (2.*Contstdg')
+Contstd3g = ContMg + (3.*Contstdg')
+
+%Wet - Trial 6
+W0G = batchG(WCS);
+W1G = batchG(W1S);
+W2G = batchG(W2S);
+W3G = batchG(W3S);
+W4G = batchG(W4S);
+W5G = batchG(W5S);
+W6G = batchG(W6S);
+W7G = batchG(W7S);
+
+wgday0 = diffR2(W0G,MSG);
+wgday1 = diffR2(W1G,MSG);
+wgday2 = diffR2(W2G,MSG);
+wgday3 = diffR2(W3G,MSG);
+wgday4 = diffR2(W4G,MSG);
+wgday5 = diffR2(W5G,MSG);
+wgday6 = diffR2(W6G,MSG);
+wgday7 = diffR2(W7G,MSG);
+
+wgmean = [wgday0(:,1); wgday1(:,1); wgday2(:,1); wgday3(:,1); wgday4(:,1); wgday5(:,1); wgday6(:,1); wgday7(:,1)];
+
+%Dry - Trial 7
+D0G = batchG(DCS);
+D1G = batchG(D1S);
+D2G = batchG(D2S);
+D3G = batchG(D3S);
+D4G = batchG(D4S);
+D5G = batchG(D5S);
+D6G = batchG(D6S);
+D7G = batchG(D7S);
+
+dgday0 = diffR2(D0G,MSG);
+dgday1 = diffR2(D1G,MSG);
+dgday2 = diffR2(D2G,MSG);
+dgday3 = diffR2(D3G,MSG);
+dgday4 = diffR2(D4G,MSG);
+dgday5 = diffR2(D5G,MSG);
+dgday6 = diffR2(D6G,MSG);
+dgday7 = diffR2(D7G,MSG);
+
+dgmean = [dgday0(:,1); dgday1(:,1); dgday2(:,1); dgday3(:,1); dgday4(:,1); dgday5(:,1); dgday6(:,1); dgday7(:,1)];
+
+%Nutrients - Trial 8
+N0G = batchG(NCS);
+N1G = batchG(N1S);
+N2G = batchG(N2S);
+N3G = batchG(N3S);
+N4G = batchG(N4S);
+N5G = batchG(N5S);
+N6G = batchG(N6S);
+N7G = batchG(N7S);
+
+ngday0 = diffR2(N0G,MSG);
+ngday1 = diffR2(N1G,MSG);
+ngday2 = diffR2(N2G,MSG);
+ngday3 = diffR2(N3G,MSG);
+ngday4 = diffR2(N4G,MSG);
+ngday5 = diffR2(N5G,MSG);
+ngday6 = diffR2(N6G,MSG);
+ngday7 = diffR2(N7G,MSG);
+
+ngmean = [ngday0(:,1); ngday1(:,1); ngday2(:,1); ngday3(:,1); ngday4(:,1); ngday5(:,1); ngday6(:,1); ngday7(:,1)];
+
+%Long - Trial 9
+L0G = batchG(LCS);
+L1G = batchG(L1S);
+L2G = batchG(L2S);
+L3G = batchG(L3S);
+L4G = batchG(L4S);
+L5G = batchG(L5S);
+L6G = batchG(L6S);
+L7G = batchG(L7S);
+
+lgday0 = diffR2(L0G,MSG);
+lgday1 = diffR2(L1G,MSG);
+lgday2 = diffR2(L2G,MSG);
+lgday3 = diffR2(L3G,MSG);
+lgday4 = diffR2(L4G,MSG);
+lgday5 = diffR2(L5G,MSG);
+lgday6 = diffR2(L6G,MSG);
+lgday7 = diffR2(L7G,MSG);
+
+lgmean = [lgday0(:,1); lgday1(:,1); lgday2(:,1); lgday3(:,1); lgday4(:,1); lgday5(:,1); lgday6(:,1); lgday7(:,1)];
+
+%Short - Trial 10
+S0G = batchG(SCS);
+S1G = batchG(S1S);
+S2G = batchG(S2S);
+S3G = batchG(S3S);
+S4G = batchG(S4S);
+S5G = batchG(S5S);
+S6G = batchG(S6S);
+S7G = batchG(S7S);
+
+sgday0 = diffR2(S0G,MSG);
+sgday1 = diffR2(S1G,MSG);
+sgday2 = diffR2(S2G,MSG);
+sgday3 = diffR2(S3G,MSG);
+sgday4 = diffR2(S4G,MSG);
+sgday5 = diffR2(S5G,MSG);
+sgday6 = diffR2(S6G,MSG);
+sgday7 = diffR2(S7G,MSG);
+
+sgmean = [sgday0(:,1); sgday1(:,1); sgday2(:,1); sgday3(:,1); sgday4(:,1); sgday5(:,1); sgday6(:,1); sgday7(:,1)];
+
+%Dark - Trial 11
+A0G = batchG(ACS);
+A1G = batchG(A1S);
+A2G = batchG(A2S);
+A3G = batchG(A3S);
+A4G = batchG(A4S);
+A5G = batchG(A5S);
+A6G = batchG(A6S);
+A7G = batchG(A7S);
+
+agday0 = diffR2(A0G,MSG);
+agday1 = diffR2(A1G,MSG);
+agday2 = diffR2(A2G,MSG);
+agday3 = diffR2(A3G,MSG);
+agday4 = diffR2(A4G,MSG);
+agday5 = diffR2(A5G,MSG);
+agday6 = diffR2(A6G,MSG);
+agday7 = diffR2(A7G,MSG);
+
+agmean = [agday0(:,1); agday1(:,1); agday2(:,1); agday3(:,1); agday4(:,1); agday5(:,1); agday6(:,1); agday7(:,1)];
+
+x = (0:7);
+figure;
+plot(x,gmean,'LineWidth',2);
+hold on
+plot(x,zgmean,'LineWidth',2);
+plot(x,pgmean,'LineWidth',2);
+plot(x,mgmean,'LineWidth',2);
+%plot(x,crmean);
+%yline(Mmean,'k');
+%yline(Mstd2pos,'k--');
+%yline(Mstd3pos,'k:');
+yline(ContMg,'k','LineWidth',2);
+yline(Contstd2g,'k--','LineWidth',2);
+yline(Contstd3g,'k:','LineWidth',2);
+%legend('Cu','Zn','Pb','Mix','Mean','2\sigma','3\sigma');
+set(gca,'fontname','arial','fontsize',18,'fontweight','bold');
+xlabel('Time(days)')
+%ylabel('Intersection Difference (Density)')
+axis([0 7 0 .65]);
+hold off
+
+%environmental only
+x = (0:7);
+figure;
+plot(x,wgmean,'LineWidth',2);
+hold on
+plot(x,dgmean,'LineWidth',2);
+plot(x,ngmean,'LineWidth',2);
+yline(ContMg,'k','LineWidth',2);
+yline(Contstd2g,'k--','LineWidth',2);
+yline(Contstd3g,'k:','LineWidth',2);
+%legend('Wet','Dry','Nutr.','Mean','2\sigma','3\sigma');
+set(gca,'fontname','arial','fontsize',18,'fontweight','bold');
+xlabel('Time(days)')
+%ylabel('Intersection Difference (Density)')
+axis([0 7 0 .65]);
+hold off
+
+%photoperiod only
+x = (0:7);
+figure;
+plot(x,lgmean,'LineWidth',2);
+hold on
+plot(x,sgmean,'LineWidth',2);
+plot(x,agmean,'LineWidth',2);
+yline(ContMg,'k','LineWidth',2);
+yline(Contstd2g,'k--','LineWidth',2);
+yline(Contstd3g,'k:','LineWidth',2);
+%legend('Long','Short','Dark','Mean','2\sigma','3\sigma');
+set(gca,'fontname','arial','fontsize',18,'fontweight','bold');
+xlabel('Time(days)')
+%ylabel('Intersection Difference (Density)')
+axis([0 7 0 .65]);
+hold off
+
+
+
+%BLUE
+MasterC = 'E:\Batch\5B\Control';
+MasterCS = imageDatastore(MasterC);
+
+%Master Control
+MCB = batchMB(MasterCS);
+MSB = batchB(MasterCS);
+
+%Copper - Trial 1
+Cu0B = batchB(CuCS);
+Cu1B = batchB(Cu1S);
+Cu2B = batchB(Cu2S);
+Cu3B = batchB(Cu3S);
+Cu4B = batchB(Cu4S);
+Cu5B = batchB(Cu5S);
+Cu6B = batchB(Cu6S);
+Cu7B = batchB(Cu7S);
+
+bday0 = diffR2(Cu0B,MSB);
+bday1 = diffR2(Cu1B,MSB);
+bday2 = diffR2(Cu2B,MSB);
+bday3 = diffR2(Cu3B,MSB);
+bday4 = diffR2(Cu4B,MSB);
+bday5 = diffR2(Cu5B,MSB);
+bday6 = diffR2(Cu6B,MSB);
+bday7 = diffR2(Cu7B,MSB);
+
+bmean = [bday0(:,1); bday1(:,1); bday2(:,1); bday3(:,1); bday4(:,1); bday5(:,1); bday6(:,1); bday7(:,1)];
+
+%Zinc - Trial 2
+Zn0B = batchB(ZnCS);
+Zn1B = batchB(Zn1S);
+Zn2B = batchB(Zn2S);
+Zn3B = batchB(Zn3S);
+Zn4B = batchB(Zn4S);
+Zn5B = batchB(Zn5S);
+Zn6B = batchB(Zn6S);
+Zn7B = batchB(Zn7S);
+
+zbday0 = diffR2(Zn0B,MSB);
+zbday1 = diffR2(Zn1B,MSB);
+zbday2 = diffR2(Zn2B,MSB);
+zbday3 = diffR2(Zn3B,MSB);
+zbday4 = diffR2(Zn4B,MSB);
+zbday5 = diffR2(Zn5B,MSB);
+zbday6 = diffR2(Zn6B,MSB);
+zbday7 = diffR2(Zn7B,MSB);
+
+zbmean = [zbday0(:,1); zbday1(:,1); zbday2(:,1); zbday3(:,1); zbday4(:,1); zbday5(:,1); zbday6(:,1); zbday7(:,1)];
+
+%Lead - Trial 3
+Pb0B = batchB(PbCS);
+Pb1B = batchB(Pb1S);
+Pb2B = batchB(Pb2S);
+Pb3B = batchB(Pb3S);
+Pb4B = batchB(Pb4S);
+Pb5B = batchB(Pb5S);
+Pb6B = batchB(Pb6S);
+Pb7B = batchB(Pb7S);
+
+pbday0 = diffR2(Pb0B,MSB);
+pbday1 = diffR2(Pb1B,MSB);
+pbday2 = diffR2(Pb2B,MSB);
+pbday3 = diffR2(Pb3B,MSB);
+pbday4 = diffR2(Pb4B,MSB);
+pbday5 = diffR2(Pb5B,MSB);
+pbday6 = diffR2(Pb6B,MSB);
+pbday7 = diffR2(Pb7B,MSB);
+
+pbmean = [pbday0(:,1); pbday1(:,1); pbday2(:,1); pbday3(:,1); pbday4(:,1); pbday5(:,1); pbday6(:,1); pbday7(:,1)];
+
+%Mix - Trial 4
+M0B = batchB(MCS);
+M1B = batchB(M1S);
+M2B = batchB(M2S);
+M3B = batchB(M3S);
+M4B = batchB(M4S);
+M5B = batchB(M5S);
+M6B = batchB(M6S);
+M7B = batchB(M7S);
+
+mbday0 = diffR2(M0B,MSB);
+mbday1 = diffR2(M1B,MSB);
+mbday2 = diffR2(M2B,MSB);
+mbday3 = diffR2(M3B,MSB);
+mbday4 = diffR2(M4B,MSB);
+mbday5 = diffR2(M5B,MSB);
+mbday6 = diffR2(M6B,MSB);
+mbday7 = diffR2(M7B,MSB);
+
+mbmean = [mbday0(:,1); mbday1(:,1); mbday2(:,1); mbday3(:,1); mbday4(:,1); mbday5(:,1); mbday6(:,1); mbday7(:,1)];
+
+%Control for comparison
+C0B = batchB(CCS);
+C1B = batchB(C1S);
+C2B = batchB(C2S);
+C3B = batchB(C3S);
+C4B = batchB(C4S);
+C5B = batchB(C5S);
+C6B = batchB(C6S);
+C7B = batchB(C7S);
+
+cbday0 = diffR2(C0B,MSB);
+cbday1 = diffR2(C1B,MSB);
+cbday2 = diffR2(C2B,MSB);
+cbday3 = diffR2(C3B,MSB);
+cbday4 = diffR2(C4B,MSB);
+cbday5 = diffR2(C5B,MSB);
+cbday6 = diffR2(C6B,MSB);
+cbday7 = diffR2(C7B,MSB);
+
+cbmean = [cbday0(:,1); cbday1(:,1); cbday2(:,1); cbday3(:,1); cbday4(:,1); cbday5(:,1); cbday6(:,1); cbday7(:,1)];
+
+ContMb = sum(cbmean)/8
+Contvarb = sum((cbmean - ContMb).^2)./(7);
+Contstdb = sqrt(Contvarb);
+Contstd2b = ContMb + (2.*Contstdb')
+Contstd3b = ContMb + (3.*Contstdb')
+
+%Wet - Trial 6
+W0B = batchB(WCS);
+W1B = batchB(W1S);
+W2B = batchB(W2S);
+W3B = batchB(W3S);
+W4B = batchB(W4S);
+W5B = batchB(W5S);
+W6B = batchB(W6S);
+W7B = batchB(W7S);
+
+wbday0 = diffR2(W0B,MSB);
+wbday1 = diffR2(W1B,MSB);
+wbday2 = diffR2(W2B,MSB);
+wbday3 = diffR2(W3B,MSB);
+wbday4 = diffR2(W4B,MSB);
+wbday5 = diffR2(W5B,MSB);
+wbday6 = diffR2(W6B,MSB);
+wbday7 = diffR2(W7B,MSB);
+
+wbmean = [wbday0(:,1); wbday1(:,1); wbday2(:,1); wbday3(:,1); wbday4(:,1); wbday5(:,1); wbday6(:,1); wbday7(:,1)];
+
+%Dry - Trial 7
+D0B = batchB(DCS);
+D1B = batchB(D1S);
+D2B = batchB(D2S);
+D3B = batchB(D3S);
+D4B = batchB(D4S);
+D5B = batchB(D5S);
+D6B = batchB(D6S);
+D7B = batchB(D7S);
+
+dbday0 = diffR2(D0B,MSB);
+dbday1 = diffR2(D1B,MSB);
+dbday2 = diffR2(D2B,MSB);
+dbday3 = diffR2(D3B,MSB);
+dbday4 = diffR2(D4B,MSB);
+dbday5 = diffR2(D5B,MSB);
+dbday6 = diffR2(D6B,MSB);
+dbday7 = diffR2(D7B,MSB);
+
+dbmean = [dbday0(:,1); dbday1(:,1); dbday2(:,1); dbday3(:,1); dbday4(:,1); dbday5(:,1); dbday6(:,1); dbday7(:,1)];
+
+%Nutrients - Trial 8
+N0B = batchB(NCS);
+N1B = batchB(N1S);
+N2B = batchB(N2S);
+N3B = batchB(N3S);
+N4B = batchB(N4S);
+N5B = batchB(N5S);
+N6B = batchB(N6S);
+N7B = batchB(N7S);
+
+nbday0 = diffR2(N0B,MSB);
+nbday1 = diffR2(N1B,MSB);
+nbday2 = diffR2(N2B,MSB);
+nbday3 = diffR2(N3B,MSB);
+nbday4 = diffR2(N4B,MSB);
+nbday5 = diffR2(N5B,MSB);
+nbday6 = diffR2(N6B,MSB);
+nbday7 = diffR2(N7B,MSB);
+
+nbmean = [nbday0(:,1); nbday1(:,1); nbday2(:,1); nbday3(:,1); nbday4(:,1); nbday5(:,1); nbday6(:,1); nbday7(:,1)];
+
+%Long - Trial 9
+L0B = batchB(LCS);
+L1B = batchB(L1S);
+L2B = batchB(L2S);
+L3B = batchB(L3S);
+L4B = batchB(L4S);
+L5B = batchB(L5S);
+L6B = batchB(L6S);
+L7B = batchB(L7S);
+
+lbday0 = diffR2(L0B,MSB);
+lbday1 = diffR2(L1B,MSB);
+lbday2 = diffR2(L2B,MSB);
+lbday3 = diffR2(L3B,MSB);
+lbday4 = diffR2(L4B,MSB);
+lbday5 = diffR2(L5B,MSB);
+lbday6 = diffR2(L6B,MSB);
+lbday7 = diffR2(L7B,MSB);
+
+lbmean = [lbday0(:,1); lbday1(:,1); lbday2(:,1); lbday3(:,1); lbday4(:,1); lbday5(:,1); lbday6(:,1); lbday7(:,1)];
+
+%Short - Trial 10
+S0B = batchB(SCS);
+S1B = batchB(S1S);
+S2B = batchB(S2S);
+S3B = batchB(S3S);
+S4B = batchB(S4S);
+S5B = batchB(S5S);
+S6B = batchB(S6S);
+S7B = batchB(S7S);
+
+sbday0 = diffR2(S0B,MSB);
+sbday1 = diffR2(S1B,MSB);
+sbday2 = diffR2(S2B,MSB);
+sbday3 = diffR2(S3B,MSB);
+sbday4 = diffR2(S4B,MSB);
+sbday5 = diffR2(S5B,MSB);
+sbday6 = diffR2(S6B,MSB);
+sbday7 = diffR2(S7B,MSB);
+
+sbmean = [sbday0(:,1); sbday1(:,1); sbday2(:,1); sbday3(:,1); sbday4(:,1); sbday5(:,1); sbday6(:,1); sbday7(:,1)];
+
+%Dark - Trial 11
+A0B = batchB(ACS);
+A1B = batchB(A1S);
+A2B = batchB(A2S);
+A3B = batchB(A3S);
+A4B = batchB(A4S);
+A5B = batchB(A5S);
+A6B = batchB(A6S);
+A7B = batchB(A7S);
+
+abday0 = diffR2(A0B,MSB);
+abday1 = diffR2(A1B,MSB);
+abday2 = diffR2(A2B,MSB);
+abday3 = diffR2(A3B,MSB);
+abday4 = diffR2(A4B,MSB);
+abday5 = diffR2(A5B,MSB);
+abday6 = diffR2(A6B,MSB);
+abday7 = diffR2(A7B,MSB);
+
+abmean = [abday0(:,1); abday1(:,1); abday2(:,1); abday3(:,1); abday4(:,1); abday5(:,1); abday6(:,1); abday7(:,1)];
+
+%metal only
+x = (0:7);
+figure;
+plot(x,bmean,'LineWidth',2);
+hold on
+plot(x,zbmean,'LineWidth',2);
+plot(x,pbmean,'LineWidth',2);
+plot(x,mbmean,'LineWidth',2);
+yline(ContMb,'k','LineWidth',2);
+yline(Contstd2b,'k--','LineWidth',2);
+yline(Contstd3b,'k:','LineWidth',2);
+%legend('Cu','Zn','Pb','Mix','Mean','2\sigma','3\sigma');
+set(gca,'fontname','arial','fontsize',18,'fontweight','bold');
+xlabel('Time(days)')
+%ylabel('Intersection Difference (Density)')
+axis([0 7 0 .65]);
+hold off
+
+%environmental only
+x = (0:7);
+figure;
+plot(x,wbmean,'LineWidth',2);
+hold on
+plot(x,dbmean,'LineWidth',2);
+plot(x,nbmean,'LineWidth',2);
+yline(ContMb,'k','LineWidth',2);
+yline(Contstd2b,'k--','LineWidth',2);
+yline(Contstd3b,'k:','LineWidth',2);
+%legend('Wet','Dry','Nutr.','Mean','2\sigma','3\sigma');
+set(gca,'fontname','arial','fontsize',18,'fontweight','bold');
+xlabel('Time(days)')
+%ylabel('Intersection Difference (Density)')
+axis([0 7 0 .65]);
+hold off
+
+%photoperiod only
+x = (0:7);
+figure;
+plot(x,lbmean,'LineWidth',2);
+hold on
+plot(x,sbmean,'LineWidth',2);
+plot(x,abmean,'LineWidth',2);
+yline(ContMb,'k','LineWidth',2);
+yline(Contstd2b,'k--','LineWidth',2);
+yline(Contstd3b,'k:','LineWidth',2);
+%legend('Long','Short','Dark','Mean','2\sigma','3\sigma');
+set(gca,'fontname','arial','fontsize',18,'fontweight','bold');
+xlabel('Time(days)')
+%ylabel('Intersection Difference (Density)')
+axis([0 7 0 .65]);
+hold off
+
+
+
+%ratio bars
+CuT = rmean + gmean + bmean
+ZnT = zrmean + zgmean + zbmean
+PbT = prmean + pgmean + pbmean
+MxT = mrmean + mgmean + mbmean
+CoT = crmean + cgmean + cbmean
+WoT = wrmean + wgmean + wbmean
+DoT = drmean + dgmean + dbmean
+NoT = nrmean + ngmean + nbmean
+LoT = lrmean + lgmean + lbmean
+SoT = srmean + sgmean + sbmean
+AoT = armean + agmean + abmean
+
+
+CuTr = rmean./CuT
+ZnTr = zrmean./ZnT
+PbTr = prmean./PbT
+MxTr = mrmean./MxT
+CoTr = crmean./CoT
+WoTr = wrmean./WoT
+DoTr = drmean./DoT
+NoTr = nrmean./NoT
+LoTr = lrmean./LoT
+SoTr = srmean./SoT
+AoTr = armean./AoT
+
+CuTg = gmean./CuT
+ZnTg = zgmean./ZnT
+PbTg = pgmean./PbT
+MxTg = mgmean./MxT
+CoTg = cgmean./CoT
+WoTg = wgmean./WoT
+DoTg = dgmean./DoT
+NoTg = ngmean./NoT
+LoTg = lgmean./LoT
+SoTg = sgmean./SoT
+AoTg = agmean./AoT
+
+CuTb = bmean./CuT
+ZnTb = zbmean./ZnT
+PbTb = pbmean./PbT
+MxTb = mbmean./MxT
+CoTb = cbmean./CoT
+WoTb = wbmean./WoT
+DoTb = dbmean./DoT
+NoTb = nbmean./NoT
+LoTb = lbmean./LoT
+SoTb = sbmean./SoT
+AoTb = abmean./AoT
+
+
+
+T1 = [CuTr(1,:) CuTg(1,:) CuTb(1,:); CuTr(2,:) CuTg(2,:) CuTb(2,:); CuTr(3,:) CuTg(3,:) CuTb(3,:); CuTr(4,:) CuTg(4,:) CuTb(4,:); CuTr(5,:) CuTg(5,:) CuTb(5,:); CuTr(6,:) CuTg(6,:) CuTb(6,:);CuTr(7,:) CuTg(7,:) CuTb(7,:); CuTr(8,:) CuTg(8,:) CuTb(8,:)];
+T2 = [ZnTr(1,:) ZnTg(1,:) ZnTb(1,:); ZnTr(2,:) ZnTg(2,:) ZnTb(2,:); ZnTr(3,:) ZnTg(3,:) ZnTb(3,:); ZnTr(4,:) ZnTg(4,:) ZnTb(4,:); ZnTr(5,:) ZnTg(5,:) ZnTb(5,:); ZnTr(6,:) ZnTg(6,:) ZnTb(6,:);ZnTr(7,:) ZnTg(7,:) ZnTb(7,:); ZnTr(8,:) ZnTg(8,:) ZnTb(8,:)];
+T3 = [PbTr(1,:) PbTg(1,:) PbTb(1,:); PbTr(2,:) PbTg(2,:) PbTb(2,:); PbTr(3,:) PbTg(3,:) PbTb(3,:); PbTr(4,:) PbTg(4,:) PbTb(4,:); PbTr(5,:) PbTg(5,:) PbTb(5,:); PbTr(6,:) PbTg(6,:) PbTb(6,:);PbTr(7,:) PbTg(7,:) PbTb(7,:); PbTr(8,:) PbTg(8,:) PbTb(8,:)];
+T4 = [MxTr(1,:) MxTg(1,:) MxTb(1,:); MxTr(2,:) MxTg(2,:) MxTb(2,:); MxTr(3,:) MxTg(3,:) MxTb(3,:); MxTr(4,:) MxTg(4,:) MxTb(4,:); MxTr(5,:) MxTg(5,:) MxTb(5,:); MxTr(6,:) MxTg(6,:) MxTb(6,:);MxTr(7,:) MxTg(7,:) MxTb(7,:); MxTr(8,:) MxTg(8,:) MxTb(8,:)];
+T5 = [CoTr(1,:) CoTg(1,:) CoTb(1,:); CoTr(2,:) CoTg(2,:) CoTb(2,:); CoTr(3,:) CoTg(3,:) CoTb(3,:); CoTr(4,:) CoTg(4,:) CoTb(4,:); CoTr(5,:) CoTg(5,:) CoTb(5,:); CoTr(6,:) CoTg(6,:) CoTb(6,:);CoTr(7,:) CoTg(7,:) CoTb(7,:); CoTr(8,:) CoTg(8,:) CoTb(8,:)];
+T6 = [WoTr(1,:) WoTg(1,:) WoTb(1,:); WoTr(2,:) WoTg(2,:) WoTb(2,:); WoTr(3,:) WoTg(3,:) WoTb(3,:); WoTr(4,:) WoTg(4,:) WoTb(4,:); WoTr(5,:) WoTg(5,:) WoTb(5,:); WoTr(6,:) WoTg(6,:) WoTb(6,:);WoTr(7,:) WoTg(7,:) WoTb(7,:); WoTr(8,:) WoTg(8,:) WoTb(8,:)];
+T7 = [DoTr(1,:) DoTg(1,:) DoTb(1,:); DoTr(2,:) DoTg(2,:) DoTb(2,:); DoTr(3,:) DoTg(3,:) DoTb(3,:); DoTr(4,:) DoTg(4,:) DoTb(4,:); DoTr(5,:) DoTg(5,:) DoTb(5,:); DoTr(6,:) DoTg(6,:) DoTb(6,:);DoTr(7,:) DoTg(7,:) DoTb(7,:); DoTr(8,:) DoTg(8,:) DoTb(8,:)];
+T8 = [NoTr(1,:) NoTg(1,:) NoTb(1,:); NoTr(2,:) NoTg(2,:) NoTb(2,:); NoTr(3,:) NoTg(3,:) NoTb(3,:); NoTr(4,:) NoTg(4,:) NoTb(4,:); NoTr(5,:) NoTg(5,:) NoTb(5,:); NoTr(6,:) NoTg(6,:) NoTb(6,:);NoTr(7,:) NoTg(7,:) NoTb(7,:); NoTr(8,:) NoTg(8,:) NoTb(8,:)];
+T9 = [LoTr(1,:) LoTg(1,:) LoTb(1,:); LoTr(2,:) LoTg(2,:) LoTb(2,:); LoTr(3,:) LoTg(3,:) LoTb(3,:); LoTr(4,:) LoTg(4,:) LoTb(4,:); LoTr(5,:) LoTg(5,:) LoTb(5,:); LoTr(6,:) LoTg(6,:) LoTb(6,:);LoTr(7,:) LoTg(7,:) LoTb(7,:); LoTr(8,:) LoTg(8,:) LoTb(8,:)];
+T10 = [SoTr(1,:) SoTg(1,:) SoTb(1,:); SoTr(2,:) SoTg(2,:) SoTb(2,:); SoTr(3,:) SoTg(3,:) SoTb(3,:); SoTr(4,:) SoTg(4,:) SoTb(4,:); SoTr(5,:) SoTg(5,:) SoTb(5,:); SoTr(6,:) SoTg(6,:) SoTb(6,:);SoTr(7,:) SoTg(7,:) SoTb(7,:); SoTr(8,:) SoTg(8,:) SoTb(8,:)];
+T11 = [AoTr(1,:) AoTg(1,:) AoTb(1,:); AoTr(2,:) AoTg(2,:) AoTb(2,:); AoTr(3,:) AoTg(3,:) AoTb(3,:); AoTr(4,:) AoTg(4,:) AoTb(4,:); AoTr(5,:) AoTg(5,:) AoTb(5,:); AoTr(6,:) AoTg(6,:) AoTb(6,:);AoTr(7,:) AoTg(7,:) AoTb(7,:); AoTr(8,:) AoTg(8,:) AoTb(8,:)];
+
+tiledlayout(6,2)
+% Top bar graph
+ax1 = nexttile;
+b1 = bar(ax1,T1)
+b1(1).FaceColor = [0.6350 0.0780 0.1840];
+b1(2).FaceColor = [0.4660 0.6740 0.1880];
+b1(3).FaceColor = [[0 0.4470 0.7410]];
+ylabel('Copper');
+axis([0 9 0 0.5])
+ax2 = nexttile;
+b2 = bar(ax2,T2)
+b2(1).FaceColor = [0.6350 0.0780 0.1840];
+b2(2).FaceColor = [0.4660 0.6740 0.1880];
+b2(3).FaceColor = [[0 0.4470 0.7410]];
+ylabel('Zinc');
+axis([0 9 0 0.5])
+ax3 = nexttile;
+b3 = bar(ax3,T3)
+b3(1).FaceColor = [0.6350 0.0780 0.1840];
+b3(2).FaceColor = [0.4660 0.6740 0.1880];
+b3(3).FaceColor = [[0 0.4470 0.7410]];
+ylabel('Lead');
+axis([0 9 0 0.5])
+ax4 = nexttile;
+b4 = bar(ax4,T4)
+b4(1).FaceColor = [0.6350 0.0780 0.1840];
+b4(2).FaceColor = [0.4660 0.6740 0.1880];
+b4(3).FaceColor = [[0 0.4470 0.7410]];
+ylabel('Mix');
+axis([0 9 0 0.5])
+ax5 = nexttile;
+b5 = bar(ax5,T5)
+b5(1).FaceColor = [0.6350 0.0780 0.1840];
+b5(2).FaceColor = [0.4660 0.6740 0.1880];
+b5(3).FaceColor = [[0 0.4470 0.7410]];
+ylabel('Cont.');
+axis([0 9 0 0.5])
+ax6 = nexttile;
+b6 = bar(ax6,T6)
+b6(1).FaceColor = [0.6350 0.0780 0.1840];
+b6(2).FaceColor = [0.4660 0.6740 0.1880];
+b6(3).FaceColor = [[0 0.4470 0.7410]];
+ylabel('Wet');
+axis([0 9 0 0.5])
+ax7 = nexttile;
+b7 = bar(ax7,T7)
+b7(1).FaceColor = [0.6350 0.0780 0.1840];
+b7(2).FaceColor = [0.4660 0.6740 0.1880];
+b7(3).FaceColor = [[0 0.4470 0.7410]];
+ylabel('Dry');
+axis([0 9 0 0.5])
+ax8 = nexttile;
+b8 = bar(ax8,T8)
+b8(1).FaceColor = [0.6350 0.0780 0.1840];
+b8(2).FaceColor = [0.4660 0.6740 0.1880];
+b8(3).FaceColor = [[0 0.4470 0.7410]];
+ylabel('Nuts.');
+axis([0 9 0 0.5])
+ax9 = nexttile;
+b9 = bar(ax9,T9)
+b9(1).FaceColor = [0.6350 0.0780 0.1840];
+b9(2).FaceColor = [0.4660 0.6740 0.1880];
+b9(3).FaceColor = [[0 0.4470 0.7410]];
+ylabel('Long');
+axis([0 9 0 0.5])
+ax10 = nexttile;
+b10 = bar(ax10,T10)
+b10(1).FaceColor = [0.6350 0.0780 0.1840];
+b10(2).FaceColor = [0.4660 0.6740 0.1880];
+b10(3).FaceColor = [[0 0.4470 0.7410]];
+ylabel('Short');
+axis([0 9 0 0.5])
+ax11 = nexttile;
+b11 = bar(ax11,T11)
+b11(1).FaceColor = [0.6350 0.0780 0.1840];
+b11(2).FaceColor = [0.4660 0.6740 0.1880];
+b11(3).FaceColor = [[0 0.4470 0.7410]];
+ylabel('Dark');
+axis([0 9 0 0.5])
+
+T1 = [rmean(1,:) gmean(1,:) bmean(1,:); rmean(2,:) gmean(2,:) bmean(2,:); rmean(3,:) gmean(3,:) bmean(3,:); rmean(4,:) gmean(4,:) bmean(4,:); rmean(5,:) gmean(5,:) bmean(5,:); rmean(6,:) gmean(6,:) bmean(6,:);rmean(7,:) gmean(7,:) bmean(7,:); rmean(8,:) gmean(8,:) bmean(8,:)];
+T2 = [zrmean(1,:) zgmean(1,:) zbmean(1,:); zrmean(2,:) zgmean(2,:) zbmean(2,:); zrmean(3,:) zgmean(3,:) zbmean(3,:); zrmean(4,:) zgmean(4,:) zbmean(4,:); zrmean(5,:) zgmean(5,:) zbmean(5,:); zrmean(6,:) zgmean(6,:) zbmean(6,:);zrmean(7,:) zgmean(7,:) zbmean(7,:); zrmean(8,:) zgmean(8,:) zbmean(8,:)];
+T3 = [prmean(1,:) pgmean(1,:) pbmean(1,:); prmean(2,:) pgmean(2,:) pbmean(2,:); prmean(3,:) pgmean(3,:) pbmean(3,:); prmean(4,:) pgmean(4,:) pbmean(4,:); prmean(5,:) pgmean(5,:) pbmean(5,:); prmean(6,:) pgmean(6,:) pbmean(6,:);prmean(7,:) pgmean(7,:) pbmean(7,:); prmean(8,:) pgmean(8,:) pbmean(8,:)];
+T4 = [mrmean(1,:) mgmean(1,:) mbmean(1,:); mrmean(2,:) mgmean(2,:) mbmean(2,:); mrmean(3,:) mgmean(3,:) mbmean(3,:); mrmean(4,:) mgmean(4,:) mbmean(4,:); mrmean(5,:) mgmean(5,:) mbmean(5,:); mrmean(6,:) mgmean(6,:) mbmean(6,:);mrmean(7,:) mgmean(7,:) mbmean(7,:); mrmean(8,:) mgmean(8,:) mbmean(8,:)];
+T5 = [crmean(1,:) cgmean(1,:) cbmean(1,:); crmean(2,:) cgmean(2,:) cbmean(2,:); crmean(3,:) cgmean(3,:) cbmean(3,:); crmean(4,:) cgmean(4,:) cbmean(4,:); crmean(5,:) cgmean(5,:) cbmean(5,:); crmean(6,:) cgmean(6,:) cbmean(6,:);crmean(7,:) cgmean(7,:) cbmean(7,:); crmean(8,:) cgmean(8,:) cbmean(8,:)];
+T6 = [wrmean(1,:) wgmean(1,:) wbmean(1,:); wrmean(2,:) wgmean(2,:) wbmean(2,:); wrmean(3,:) wgmean(3,:) wbmean(3,:); wrmean(4,:) wgmean(4,:) wbmean(4,:); wrmean(5,:) wgmean(5,:) wbmean(5,:); wrmean(6,:) wgmean(6,:) wbmean(6,:); wrmean(7,:) wgmean(7,:) wbmean(7,:); wrmean(8,:) wgmean(8,:) wbmean(8,:)];
+T7 = [drmean(1,:) dgmean(1,:) dbmean(1,:); drmean(2,:) dgmean(2,:) dbmean(2,:); drmean(3,:) dgmean(3,:) dbmean(3,:); drmean(4,:) dgmean(4,:) dbmean(4,:); drmean(5,:) dgmean(5,:) dbmean(5,:); drmean(6,:) dgmean(6,:) dbmean(6,:); drmean(7,:) dgmean(7,:) dbmean(7,:); drmean(8,:) dgmean(8,:) dbmean(8,:)];
+T8 = [nrmean(1,:) ngmean(1,:) nbmean(1,:); nrmean(2,:) ngmean(2,:) nbmean(2,:); nrmean(3,:) ngmean(3,:) nbmean(3,:); nrmean(4,:) ngmean(4,:) nbmean(4,:); nrmean(5,:) ngmean(5,:) nbmean(5,:); nrmean(6,:) ngmean(6,:) nbmean(6,:); nrmean(7,:) ngmean(7,:) nbmean(7,:); nrmean(8,:) ngmean(8,:) nbmean(8,:)];
+T9 = [lrmean(1,:) lgmean(1,:) lbmean(1,:); lrmean(2,:) lgmean(2,:) lbmean(2,:); lrmean(3,:) lgmean(3,:) lbmean(3,:); lrmean(4,:) lgmean(4,:) lbmean(4,:); lrmean(5,:) lgmean(5,:) lbmean(5,:); lrmean(6,:) lgmean(6,:) lbmean(6,:); lrmean(7,:) lgmean(7,:) lbmean(7,:); lrmean(8,:) lgmean(8,:) lbmean(8,:)];
+T10 = [srmean(1,:) sgmean(1,:) sbmean(1,:); srmean(2,:) sgmean(2,:) sbmean(2,:); srmean(3,:) sgmean(3,:) sbmean(3,:); srmean(4,:) sgmean(4,:) sbmean(4,:); srmean(5,:) sgmean(5,:) sbmean(5,:); srmean(6,:) sgmean(6,:) sbmean(6,:); srmean(7,:) sgmean(7,:) sbmean(7,:); srmean(8,:) sgmean(8,:) sbmean(8,:)];
+T11 = [armean(1,:) agmean(1,:) abmean(1,:); armean(2,:) agmean(2,:) abmean(2,:); armean(3,:) agmean(3,:) abmean(3,:); armean(4,:) agmean(4,:) abmean(4,:); armean(5,:) agmean(5,:) abmean(5,:); armean(6,:) agmean(6,:) abmean(6,:); armean(7,:) agmean(7,:) abmean(7,:); armean(8,:) agmean(8,:) abmean(8,:)];
+
+tiledlayout(6,2)
+% Top bar graph
+ax1 = nexttile;
+b1 = bar(ax1,T1)
+b1(1).FaceColor = [0.6350 0.0780 0.1840];
+b1(2).FaceColor = [0.4660 0.6740 0.1880];
+b1(3).FaceColor = [[0 0.4470 0.7410]];
+ylabel('Copper');
+axis([0 9 0 1])
+ax2 = nexttile;
+b2 = bar(ax2,T2)
+b2(1).FaceColor = [0.6350 0.0780 0.1840];
+b2(2).FaceColor = [0.4660 0.6740 0.1880];
+b2(3).FaceColor = [[0 0.4470 0.7410]];
+ylabel('Zinc');
+axis([0 9 0 1])
+ax3 = nexttile;
+b3 = bar(ax3,T3)
+b3(1).FaceColor = [0.6350 0.0780 0.1840];
+b3(2).FaceColor = [0.4660 0.6740 0.1880];
+b3(3).FaceColor = [[0 0.4470 0.7410]];
+ylabel('Lead');
+axis([0 9 0 1])
+ax4 = nexttile;
+b4 = bar(ax4,T4)
+b4(1).FaceColor = [0.6350 0.0780 0.1840];
+b4(2).FaceColor = [0.4660 0.6740 0.1880];
+b4(3).FaceColor = [[0 0.4470 0.7410]];
+ylabel('Mix');
+axis([0 9 0 1])
+ax5 = nexttile;
+b5 = bar(ax5,T5)
+b5(1).FaceColor = [0.6350 0.0780 0.1840];
+b5(2).FaceColor = [0.4660 0.6740 0.1880];
+b5(3).FaceColor = [[0 0.4470 0.7410]];
+ylabel('Cont.');
+axis([0 9 0 1])
+ax6 = nexttile;
+b6 = bar(ax6,T6)
+b6(1).FaceColor = [0.6350 0.0780 0.1840];
+b6(2).FaceColor = [0.4660 0.6740 0.1880];
+b6(3).FaceColor = [[0 0.4470 0.7410]];
+ylabel('Wet');
+axis([0 9 0 1])
+ax7 = nexttile;
+b7 = bar(ax7,T7)
+b7(1).FaceColor = [0.6350 0.0780 0.1840];
+b7(2).FaceColor = [0.4660 0.6740 0.1880];
+b7(3).FaceColor = [[0 0.4470 0.7410]];
+ylabel('Dry');
+axis([0 9 0 1])
+ax8 = nexttile;
+b8 = bar(ax8,T8)
+b8(1).FaceColor = [0.6350 0.0780 0.1840];
+b8(2).FaceColor = [0.4660 0.6740 0.1880];
+b8(3).FaceColor = [[0 0.4470 0.7410]];
+ylabel('Nuts.');
+axis([0 9 0 1])
+ax9 = nexttile;
+b9 = bar(ax9,T9)
+b9(1).FaceColor = [0.6350 0.0780 0.1840];
+b9(2).FaceColor = [0.4660 0.6740 0.1880];
+b9(3).FaceColor = [[0 0.4470 0.7410]];
+ylabel('Long');
+axis([0 9 0 1])
+ax10 = nexttile;
+b10 = bar(ax10,T10)
+b10(1).FaceColor = [0.6350 0.0780 0.1840];
+b10(2).FaceColor = [0.4660 0.6740 0.1880];
+b10(3).FaceColor = [[0 0.4470 0.7410]];
+ylabel('Short');
+axis([0 9 0 1])
+ax11 = nexttile;
+b11 = bar(ax11,T11)
+b11(1).FaceColor = [0.6350 0.0780 0.1840];
+b11(2).FaceColor = [0.4660 0.6740 0.1880];
+b11(3).FaceColor = [[0 0.4470 0.7410]];
+ylabel('Dark');
+axis([0 9 0 1])

--- a/Batch_dtwM_E_B.m
+++ b/Batch_dtwM_E_B.m
@@ -1,0 +1,1255 @@
+%DTW versus
+%This code is for just running the dtw comparisons for single color
+
+MasterC = 'E:\Batch\5B\Control';
+%MasterC = 'E:\Batch\5B\Cont'; %not appreciably better....
+MasterCS = imageDatastore(MasterC);
+
+MCR = batchR(MasterCS); %194 control maintained instead of 1 master
+MCG = batchG(MasterCS);
+MCB = batchB(MasterCS);
+
+MCRG = [MCR;MCG];
+MCRB = [MCR;MCB];
+MCGB = [MCG;MCB];
+
+%need make function for batch process
+%DTW1 = dtw(MCR,Cu0R(:,15));
+%DTW2 = dtw2(MCR,Cu0R(:,1),(MCR-Cu0R(:,1)));
+
+%copper trial 1
+CuC = 'E:\Batch\5B\T1Cu\0';
+Cu1 = 'E:\Batch\5B\T1Cu\1';
+Cu2 = 'E:\Batch\5B\T1Cu\2';
+Cu3 = 'E:\Batch\5B\T1Cu\3';
+Cu4 = 'E:\Batch\5B\T1Cu\4';
+Cu5 = 'E:\Batch\5B\T1Cu\5';
+Cu6 = 'E:\Batch\5B\T1Cu\6';
+Cu7 = 'E:\Batch\5B\T1Cu\7';
+CuCS = imageDatastore(CuC);
+Cu1S = imageDatastore(Cu1);
+Cu2S = imageDatastore(Cu2);
+Cu3S = imageDatastore(Cu3);
+Cu4S = imageDatastore(Cu4);
+Cu5S = imageDatastore(Cu5);
+Cu6S = imageDatastore(Cu6);
+Cu7S = imageDatastore(Cu7);
+
+Cu0R = batchR(CuCS);
+Cu1R = batchR(Cu1S);
+Cu2R = batchR(Cu2S);
+Cu3R = batchR(Cu3S);
+Cu4R = batchR(Cu4S);
+Cu5R = batchR(Cu5S);
+Cu6R = batchR(Cu6S);
+Cu7R = batchR(Cu7S);
+
+Cu0G = batchG(CuCS);
+Cu1G = batchG(Cu1S);
+Cu2G = batchG(Cu2S);
+Cu3G = batchG(Cu3S);
+Cu4G = batchG(Cu4S);
+Cu5B = batchG(Cu5S);
+Cu6G = batchG(Cu6S);
+Cu7G = batchG(Cu7S);
+
+Cu0B = batchB(CuCS);
+Cu1B = batchB(Cu1S);
+Cu2B = batchB(Cu2S);
+Cu3B = batchB(Cu3S);
+Cu4B = batchB(Cu4S);
+Cu5B = batchB(Cu5S);
+Cu6B = batchB(Cu6S);
+Cu7B = batchB(Cu7S);
+
+CuRG0 = [Cu0R;Cu0G];
+CuRG1 = [Cu1R;Cu1G];
+CuRG2 = [Cu2R;Cu2G];
+CuRG3 = [Cu3R;Cu3G];
+CuRG4 = [Cu4R;Cu4G];
+CuRG5 = [Cu5R;Cu5B];
+CuRG6 = [Cu6R;Cu6G];
+CuRG7 = [Cu7R;Cu7G];
+
+CuRB0 = [Cu0R;Cu0B];
+CuRB1 = [Cu1R;Cu1B];
+CuRB2 = [Cu2R;Cu2B];
+CuRB3 = [Cu3R;Cu3B];
+CuRB4 = [Cu4R;Cu4B];
+CuRB5 = [Cu5R;Cu5B];
+CuRB6 = [Cu6R;Cu6B];
+CuRB7 = [Cu7R;Cu7B];
+
+CuGB0 = [Cu0G;Cu0B];
+CuGB1 = [Cu1G;Cu1B];
+CuGB2 = [Cu2G;Cu2B];
+CuGB3 = [Cu3G;Cu3B];
+CuGB4 = [Cu4G;Cu4B];
+CuGB5 = [Cu5B;Cu5B];
+CuGB6 = [Cu6G;Cu6B];
+CuGB7 = [Cu7G;Cu7B];
+
+CuDTW0RG = one(MCRG,CuRG0);
+CuDTW1RG = one(MCRG,CuRG1);
+CuDTW2RG = one(MCRG,CuRG2);
+CuDTW3RG = one(MCRG,CuRG3);
+CuDTW4RG = one(MCRG,CuRG4);
+CuDTW5RG = one(MCRG,CuRG5);
+CuDTW6RG = one(MCRG,CuRG6);
+CuDTW7RG = one(MCRG,CuRG7);
+
+CuDTW0RB = one(MCRB,CuRB0);
+CuDTW1RB = one(MCRB,CuRB1);
+CuDTW2RB = one(MCRB,CuRB2);
+CuDTW3RB = one(MCRB,CuRB3);
+CuDTW4RB = one(MCRB,CuRB4);
+CuDTW5RB = one(MCRB,CuRB5);
+CuDTW6RB = one(MCRB,CuRB6);
+CuDTW7RB = one(MCRB,CuRB7);
+
+CuDTW0GB = one(MCGB,CuGB0);
+CuDTW1GB = one(MCGB,CuGB1);
+CuDTW2GB = one(MCGB,CuGB2);
+CuDTW3GB = one(MCGB,CuGB3);
+CuDTW4GB = one(MCGB,CuGB4);
+CuDTW5BB = one(MCGB,CuGB5);
+CuDTW6GB = one(MCGB,CuGB6);
+CuDTW7GB = one(MCGB,CuGB7);
+
+CuDTWRG = [CuDTW0RG(:,1); CuDTW1RG(:,1); CuDTW2RG(:,1); CuDTW3RG(:,1); CuDTW4RG(:,1); CuDTW5RG(:,1); CuDTW6RG(:,1); CuDTW7RG(:,1)];
+Cuone = [CuDTW0RB(:,1); CuDTW1RB(:,1); CuDTW2RB(:,1); CuDTW3RB(:,1); CuDTW4RB(:,1); CuDTW5RB(:,1); CuDTW6RB(:,1); CuDTW7RB(:,1)];
+CuDTWGB = [CuDTW0GB(:,1); CuDTW1GB(:,1); CuDTW2GB(:,1); CuDTW3GB(:,1); CuDTW4GB(:,1); CuDTW5BB(:,1); CuDTW6GB(:,1); CuDTW7GB(:,1)];
+
+%x = (0:7);
+%figure;
+%plot(x,CuDTWRG,'LineWidth',2);
+%hold on
+%plot(x,Cuone,'LineWidth',2);
+%plot(x,CuDTWGB,'LineWidth',2);
+%legend('CuRG','CuRB','CuGB');
+
+%zinc trial 2
+ZnC = 'E:\Batch\5B\T2Zn\0';
+Zn1 = 'E:\Batch\5B\T2Zn\1';
+Zn2 = 'E:\Batch\5B\T2Zn\2';
+Zn3 = 'E:\Batch\5B\T2Zn\3';
+Zn4 = 'E:\Batch\5B\T2Zn\4';
+Zn5 = 'E:\Batch\5B\T2Zn\5';
+Zn6 = 'E:\Batch\5B\T2Zn\6';
+Zn7 = 'E:\Batch\5B\T2Zn\7';
+ZnCS = imageDatastore(ZnC);
+Zn1S = imageDatastore(Zn1);
+Zn2S = imageDatastore(Zn2);
+Zn3S = imageDatastore(Zn3);
+Zn4S = imageDatastore(Zn4);
+Zn5S = imageDatastore(Zn5);
+Zn6S = imageDatastore(Zn6);
+Zn7S = imageDatastore(Zn7);
+
+Zn0R = batchR(ZnCS);
+Zn1R = batchR(Zn1S);
+Zn2R = batchR(Zn2S);
+Zn3R = batchR(Zn3S);
+Zn4R = batchR(Zn4S);
+Zn5R = batchR(Zn5S);
+Zn6R = batchR(Zn6S);
+Zn7R = batchR(Zn7S);
+
+Zn0G = batchG(ZnCS);
+Zn1G = batchG(Zn1S);
+Zn2G = batchG(Zn2S);
+Zn3G = batchG(Zn3S);
+Zn4G = batchG(Zn4S);
+Zn5B = batchG(Zn5S);
+Zn6G = batchG(Zn6S);
+Zn7G = batchG(Zn7S);
+
+Zn0B = batchB(ZnCS);
+Zn1B = batchB(Zn1S);
+Zn2B = batchB(Zn2S);
+Zn3B = batchB(Zn3S);
+Zn4B = batchB(Zn4S);
+Zn5B = batchB(Zn5S);
+Zn6B = batchB(Zn6S);
+Zn7B = batchB(Zn7S);
+
+ZnRG0 = [Zn0R;Zn0G];
+ZnRG1 = [Zn1R;Zn1G];
+ZnRG2 = [Zn2R;Zn2G];
+ZnRG3 = [Zn3R;Zn3G];
+ZnRG4 = [Zn4R;Zn4G];
+ZnRG5 = [Zn5R;Zn5B];
+ZnRG6 = [Zn6R;Zn6G];
+ZnRG7 = [Zn7R;Zn7G];
+
+ZnRB0 = [Zn0R;Zn0B];
+ZnRB1 = [Zn1R;Zn1B];
+ZnRB2 = [Zn2R;Zn2B];
+ZnRB3 = [Zn3R;Zn3B];
+ZnRB4 = [Zn4R;Zn4B];
+ZnRB5 = [Zn5R;Zn5B];
+ZnRB6 = [Zn6R;Zn6B];
+ZnRB7 = [Zn7R;Zn7B];
+
+ZnGB0 = [Zn0G;Zn0B];
+ZnGB1 = [Zn1G;Zn1B];
+ZnGB2 = [Zn2G;Zn2B];
+ZnGB3 = [Zn3G;Zn3B];
+ZnGB4 = [Zn4G;Zn4B];
+ZnGB5 = [Zn5B;Zn5B];
+ZnGB6 = [Zn6G;Zn6B];
+ZnGB7 = [Zn7G;Zn7B];
+
+ZnDTW0RG = one(MCRG,ZnRG0);
+ZnDTW1RG = one(MCRG,ZnRG1);
+ZnDTW2RG = one(MCRG,ZnRG2);
+ZnDTW3RG = one(MCRG,ZnRG3);
+ZnDTW4RG = one(MCRG,ZnRG4);
+ZnDTW5RG = one(MCRG,ZnRG5);
+ZnDTW6RG = one(MCRG,ZnRG6);
+ZnDTW7RG = one(MCRG,ZnRG7);
+
+ZnDTW0RB = one(MCRB,ZnRB0);
+ZnDTW1RB = one(MCRB,ZnRB1);
+ZnDTW2RB = one(MCRB,ZnRB2);
+ZnDTW3RB = one(MCRB,ZnRB3);
+ZnDTW4RB = one(MCRB,ZnRB4);
+ZnDTW5RB = one(MCRB,ZnRB5);
+ZnDTW6RB = one(MCRB,ZnRB6);
+ZnDTW7RB = one(MCRB,ZnRB7);
+
+ZnDTW0GB = one(MCGB,ZnGB0);
+ZnDTW1GB = one(MCGB,ZnGB1);
+ZnDTW2GB = one(MCGB,ZnGB2);
+ZnDTW3GB = one(MCGB,ZnGB3);
+ZnDTW4GB = one(MCGB,ZnGB4);
+ZnDTW5BB = one(MCGB,ZnGB5);
+ZnDTW6GB = one(MCGB,ZnGB6);
+ZnDTW7GB = one(MCGB,ZnGB7);
+
+ZnDTWGB = [ZnDTW0GB(:,1); ZnDTW1GB(:,1); ZnDTW2GB(:,1); ZnDTW3GB(:,1); ZnDTW4GB(:,1); ZnDTW5BB(:,1); ZnDTW6GB(:,1); ZnDTW7GB(:,1)];
+ZnDTWRG = [ZnDTW0RG(:,1); ZnDTW1RG(:,1); ZnDTW2RG(:,1); ZnDTW3RG(:,1); ZnDTW4RG(:,1); ZnDTW5RG(:,1); ZnDTW6RG(:,1); ZnDTW7RG(:,1)];
+Znone = [ZnDTW0RB(:,1); ZnDTW1RB(:,1); ZnDTW2RB(:,1); ZnDTW3RB(:,1); ZnDTW4RB(:,1); ZnDTW5RB(:,1); ZnDTW6RB(:,1); ZnDTW7RB(:,1)];
+
+%lead trial 3
+PbC = 'E:\Batch\5B\T3Pb\0';
+Pb1 = 'E:\Batch\5B\T3Pb\1';
+Pb2 = 'E:\Batch\5B\T3Pb\2';
+Pb3 = 'E:\Batch\5B\T3Pb\3';
+Pb4 = 'E:\Batch\5B\T3Pb\4';
+Pb5 = 'E:\Batch\5B\T3Pb\5';
+Pb6 = 'E:\Batch\5B\T3Pb\6';
+Pb7 = 'E:\Batch\5B\T3Pb\7';
+PbCS = imageDatastore(PbC);
+Pb1S = imageDatastore(Pb1);
+Pb2S = imageDatastore(Pb2);
+Pb3S = imageDatastore(Pb3);
+Pb4S = imageDatastore(Pb4);
+Pb5S = imageDatastore(Pb5);
+Pb6S = imageDatastore(Pb6);
+Pb7S = imageDatastore(Pb7);
+Pb0R = batchR(PbCS);
+Pb1R = batchR(Pb1S);
+Pb2R = batchR(Pb2S);
+Pb3R = batchR(Pb3S);
+Pb4R = batchR(Pb4S);
+Pb5R = batchR(Pb5S);
+Pb6R = batchR(Pb6S);
+Pb7R = batchR(Pb7S);
+
+Pb0G = batchG(PbCS);
+Pb1G = batchG(Pb1S);
+Pb2G = batchG(Pb2S);
+Pb3G = batchG(Pb3S);
+Pb4G = batchG(Pb4S);
+Pb5B = batchG(Pb5S);
+Pb6G = batchG(Pb6S);
+Pb7G = batchG(Pb7S);
+
+Pb0B = batchB(PbCS);
+Pb1B = batchB(Pb1S);
+Pb2B = batchB(Pb2S);
+Pb3B = batchB(Pb3S);
+Pb4B = batchB(Pb4S);
+Pb5B = batchB(Pb5S);
+Pb6B = batchB(Pb6S);
+Pb7B = batchB(Pb7S);
+
+PbRG0 = [Pb0R;Pb0G];
+PbRG1 = [Pb1R;Pb1G];
+PbRG2 = [Pb2R;Pb2G];
+PbRG3 = [Pb3R;Pb3G];
+PbRG4 = [Pb4R;Pb4G];
+PbRG5 = [Pb5R;Pb5B];
+PbRG6 = [Pb6R;Pb6G];
+PbRG7 = [Pb7R;Pb7G];
+
+PbRB0 = [Pb0R;Pb0B];
+PbRB1 = [Pb1R;Pb1B];
+PbRB2 = [Pb2R;Pb2B];
+PbRB3 = [Pb3R;Pb3B];
+PbRB4 = [Pb4R;Pb4B];
+PbRB5 = [Pb5R;Pb5B];
+PbRB6 = [Pb6R;Pb6B];
+PbRB7 = [Pb7R;Pb7B];
+
+PbGB0 = [Pb0G;Pb0B];
+PbGB1 = [Pb1G;Pb1B];
+PbGB2 = [Pb2G;Pb2B];
+PbGB3 = [Pb3G;Pb3B];
+PbGB4 = [Pb4G;Pb4B];
+PbGB5 = [Pb5B;Pb5B];
+PbGB6 = [Pb6G;Pb6B];
+PbGB7 = [Pb7G;Pb7B];
+
+PbDTW0RG = one(MCRG,PbRG0);
+PbDTW1RG = one(MCRG,PbRG1);
+PbDTW2RG = one(MCRG,PbRG2);
+PbDTW3RG = one(MCRG,PbRG3);
+PbDTW4RG = one(MCRG,PbRG4);
+PbDTW5RG = one(MCRG,PbRG5);
+PbDTW6RG = one(MCRG,PbRG6);
+PbDTW7RG = one(MCRG,PbRG7);
+
+PbDTW0RB = one(MCRB,PbRB0);
+PbDTW1RB = one(MCRB,PbRB1);
+PbDTW2RB = one(MCRB,PbRB2);
+PbDTW3RB = one(MCRB,PbRB3);
+PbDTW4RB = one(MCRB,PbRB4);
+PbDTW5RB = one(MCRB,PbRB5);
+PbDTW6RB = one(MCRB,PbRB6);
+PbDTW7RB = one(MCRB,PbRB7);
+
+PbDTW0GB = one(MCGB,PbGB0);
+PbDTW1GB = one(MCGB,PbGB1);
+PbDTW2GB = one(MCGB,PbGB2);
+PbDTW3GB = one(MCGB,PbGB3);
+PbDTW4GB = one(MCGB,PbGB4);
+PbDTW5BB = one(MCGB,PbGB5);
+PbDTW6GB = one(MCGB,PbGB6);
+PbDTW7GB = one(MCGB,PbGB7);
+
+PbDTWGB = [PbDTW0GB(:,1); PbDTW1GB(:,1); PbDTW2GB(:,1); PbDTW3GB(:,1); PbDTW4GB(:,1); PbDTW5BB(:,1); PbDTW6GB(:,1); PbDTW7GB(:,1)];
+PbDTWRG = [PbDTW0RG(:,1); PbDTW1RG(:,1); PbDTW2RG(:,1); PbDTW3RG(:,1); PbDTW4RG(:,1); PbDTW5RG(:,1); PbDTW6RG(:,1); PbDTW7RG(:,1)];
+Pbone = [PbDTW0RB(:,1); PbDTW1RB(:,1); PbDTW2RB(:,1); PbDTW3RB(:,1); PbDTW4RB(:,1); PbDTW5RB(:,1); PbDTW6RB(:,1); PbDTW7RB(:,1)];
+
+%Mix - Trial 4
+MC = 'E:\Batch\5B\T4Mix\0';
+M1 = 'E:\Batch\5B\T4Mix\1';
+M2 = 'E:\Batch\5B\T4Mix\2';
+M3 = 'E:\Batch\5B\T4Mix\3';
+M4 = 'E:\Batch\5B\T4Mix\4';
+M5 = 'E:\Batch\5B\T4Mix\5';
+M6 = 'E:\Batch\5B\T4Mix\6';
+M7 = 'E:\Batch\5B\T4Mix\7';
+MCS = imageDatastore(MC);
+M1S = imageDatastore(M1);
+M2S = imageDatastore(M2);
+M3S = imageDatastore(M3);
+M4S = imageDatastore(M4);
+M5S = imageDatastore(M5);
+M6S = imageDatastore(M6);
+M7S = imageDatastore(M7);
+M0R = batchR(MCS);
+M1R = batchR(M1S);
+M2R = batchR(M2S);
+M3R = batchR(M3S);
+M4R = batchR(M4S);
+M5R = batchR(M5S);
+M6R = batchR(M6S);
+M7R = batchR(M7S);
+
+M0G = batchG(MCS);
+M1G = batchG(M1S);
+M2G = batchG(M2S);
+M3G = batchG(M3S);
+M4G = batchG(M4S);
+M5B = batchG(M5S);
+M6G = batchG(M6S);
+M7G = batchG(M7S);
+
+M0B = batchB(MCS);
+M1B = batchB(M1S);
+M2B = batchB(M2S);
+M3B = batchB(M3S);
+M4B = batchB(M4S);
+M5B = batchB(M5S);
+M6B = batchB(M6S);
+M7B = batchB(M7S);
+
+MRG0 = [M0R;M0G];
+MRG1 = [M1R;M1G];
+MRG2 = [M2R;M2G];
+MRG3 = [M3R;M3G];
+MRG4 = [M4R;M4G];
+MRG5 = [M5R;M5B];
+MRG6 = [M6R;M6G];
+MRG7 = [M7R;M7G];
+
+MRB0 = [M0R;M0B];
+MRB1 = [M1R;M1B];
+MRB2 = [M2R;M2B];
+MRB3 = [M3R;M3B];
+MRB4 = [M4R;M4B];
+MRB5 = [M5R;M5B];
+MRB6 = [M6R;M6B];
+MRB7 = [M7R;M7B];
+
+MGB0 = [M0G;M0B];
+MGB1 = [M1G;M1B];
+MGB2 = [M2G;M2B];
+MGB3 = [M3G;M3B];
+MGB4 = [M4G;M4B];
+MGB5 = [M5B;M5B];
+MGB6 = [M6G;M6B];
+MGB7 = [M7G;M7B];
+
+MDTW0RG = one(MCRG,MRG0);
+MDTW1RG = one(MCRG,MRG1);
+MDTW2RG = one(MCRG,MRG2);
+MDTW3RG = one(MCRG,MRG3);
+MDTW4RG = one(MCRG,MRG4);
+MDTW5RG = one(MCRG,MRG5);
+MDTW6RG = one(MCRG,MRG6);
+MDTW7RG = one(MCRG,MRG7);
+
+MDTW0RB = one(MCRB,MRB0);
+MDTW1RB = one(MCRB,MRB1);
+MDTW2RB = one(MCRB,MRB2);
+MDTW3RB = one(MCRB,MRB3);
+MDTW4RB = one(MCRB,MRB4);
+MDTW5RB = one(MCRB,MRB5);
+MDTW6RB = one(MCRB,MRB6);
+MDTW7RB = one(MCRB,MRB7);
+
+MDTW0GB = one(MCGB,MGB0);
+MDTW1GB = one(MCGB,MGB1);
+MDTW2GB = one(MCGB,MGB2);
+MDTW3GB = one(MCGB,MGB3);
+MDTW4GB = one(MCGB,MGB4);
+MDTW5BB = one(MCGB,MGB5);
+MDTW6GB = one(MCGB,MGB6);
+MDTW7GB = one(MCGB,MGB7);
+
+MDTWGB = [MDTW0GB(:,1); MDTW1GB(:,1); MDTW2GB(:,1); MDTW3GB(:,1); MDTW4GB(:,1); MDTW5BB(:,1); MDTW6GB(:,1); MDTW7GB(:,1)];
+MDTWRG = [MDTW0RG(:,1); MDTW1RG(:,1); MDTW2RG(:,1); MDTW3RG(:,1); MDTW4RG(:,1); MDTW5RG(:,1); MDTW6RG(:,1); MDTW7RG(:,1)];
+Mone = [MDTW0RB(:,1); MDTW1RB(:,1); MDTW2RB(:,1); MDTW3RB(:,1); MDTW4RB(:,1); MDTW5RB(:,1); MDTW6RB(:,1); MDTW7RB(:,1)];
+
+%Control for comparison
+CC = 'E:\Batch\5B\T5Con\0';
+C1 = 'E:\Batch\5B\T5Con\1';
+C2 = 'E:\Batch\5B\T5Con\2';
+C3 = 'E:\Batch\5B\T5Con\3';
+C4 = 'E:\Batch\5B\T5Con\4';
+C5 = 'E:\Batch\5B\T5Con\5';
+C6 = 'E:\Batch\5B\T5Con\6';
+C7 = 'E:\Batch\5B\T5Con\7';
+CCS = imageDatastore(CC);
+C1S = imageDatastore(C1);
+C2S = imageDatastore(C2);
+C3S = imageDatastore(C3);
+C4S = imageDatastore(C4);
+C5S = imageDatastore(C5);
+C6S = imageDatastore(C6);
+C7S = imageDatastore(C7);
+C0R = batchR(CCS);
+C1R = batchR(C1S);
+C2R = batchR(C2S);
+C3R = batchR(C3S);
+C4R = batchR(C4S);
+C5R = batchR(C5S);
+C6R = batchR(C6S);
+C7R = batchR(C7S);
+
+C0G = batchG(CCS);
+C1G = batchG(C1S);
+C2G = batchG(C2S);
+C3G = batchG(C3S);
+C4G = batchG(C4S);
+C5B = batchG(C5S);
+C6G = batchG(C6S);
+C7G = batchG(C7S);
+
+C0B = batchB(CCS);
+C1B = batchB(C1S);
+C2B = batchB(C2S);
+C3B = batchB(C3S);
+C4B = batchB(C4S);
+C5B = batchB(C5S);
+C6B = batchB(C6S);
+C7B = batchB(C7S);
+
+CRG0 = [C0R;C0G];
+CRG1 = [C1R;C1G];
+CRG2 = [C2R;C2G];
+CRG3 = [C3R;C3G];
+CRG4 = [C4R;C4G];
+CRG5 = [C5R;C5B];
+CRG6 = [C6R;C6G];
+CRG7 = [C7R;C7G];
+
+CRB0 = [C0R;C0B];
+CRB1 = [C1R;C1B];
+CRB2 = [C2R;C2B];
+CRB3 = [C3R;C3B];
+CRB4 = [C4R;C4B];
+CRB5 = [C5R;C5B];
+CRB6 = [C6R;C6B];
+CRB7 = [C7R;C7B];
+
+CGB0 = [C0G;C0B];
+CGB1 = [C1G;C1B];
+CGB2 = [C2G;C2B];
+CGB3 = [C3G;C3B];
+CGB4 = [C4G;C4B];
+CGB5 = [C5B;C5B];
+CGB6 = [C6G;C6B];
+CGB7 = [C7G;C7B];
+
+CDTW0RG = one(MCRG,CRG0);
+CDTW1RG = one(MCRG,CRG1);
+CDTW2RG = one(MCRG,CRG2);
+CDTW3RG = one(MCRG,CRG3);
+CDTW4RG = one(MCRG,CRG4);
+CDTW5RG = one(MCRG,CRG5);
+CDTW6RG = one(MCRG,CRG6);
+CDTW7RG = one(MCRG,CRG7);
+
+CDTW0RB = one(MCRB,CRB0);
+CDTW1RB = one(MCRB,CRB1);
+CDTW2RB = one(MCRB,CRB2);
+CDTW3RB = one(MCRB,CRB3);
+CDTW4RB = one(MCRB,CRB4);
+CDTW5RB = one(MCRB,CRB5);
+CDTW6RB = one(MCRB,CRB6);
+CDTW7RB = one(MCRB,CRB7);
+
+CDTW0GB = one(MCGB,CGB0);
+CDTW1GB = one(MCGB,CGB1);
+CDTW2GB = one(MCGB,CGB2);
+CDTW3GB = one(MCGB,CGB3);
+CDTW4GB = one(MCGB,CGB4);
+CDTW5BB = one(MCGB,CGB5);
+CDTW6GB = one(MCGB,CGB6);
+CDTW7GB = one(MCGB,CGB7);
+
+CDTWGB = [CDTW0GB(:,1); CDTW1GB(:,1); CDTW2GB(:,1); CDTW3GB(:,1); CDTW4GB(:,1); CDTW5BB(:,1); CDTW6GB(:,1); CDTW7GB(:,1)];
+
+ContMb = sum(CDTWGB)/8
+Contvarb = sum((CDTWGB - ContMb).^2)./(7);
+Contstdb = sqrt(Contvarb);
+Contstd2b = ContMb + (2.*Contstdb')
+Contstd3b = ContMb + (3.*Contstdb')
+
+CDTWRG = [CDTW0RG(:,1); CDTW1RG(:,1); CDTW2RG(:,1); CDTW3RG(:,1); CDTW4RG(:,1); CDTW5RG(:,1); CDTW6RG(:,1); CDTW7RG(:,1)];
+
+ContMg = sum(CDTWRG)/8
+Contvarg = sum((CDTWRG - ContMg).^2)./(7);
+Contstdg = sqrt(Contvarg);
+Contstd2g = ContMg + (2.*Contstdg')
+Contstd3g = ContMg + (3.*Contstdg')
+
+Cone = [CDTW0RB(:,1); CDTW1RB(:,1); CDTW2RB(:,1); CDTW3RB(:,1); CDTW4RB(:,1); CDTW5RB(:,1); CDTW6RB(:,1); CDTW7RB(:,1)];
+
+ContM = sum(Cone)/8
+Contvar = sum((Cone - ContM).^2)./(7);
+Contstd = sqrt(Contvar);
+Contstd2 = ContM + (2.*Contstd')
+Contstd3 = ContM + (3.*Contstd')
+
+%Wet - Trial 6
+WC = 'E:\Batch\5B\T6Wet\0';
+W1 = 'E:\Batch\5B\T6Wet\1';
+W2 = 'E:\Batch\5B\T6Wet\2';
+W3 = 'E:\Batch\5B\T6Wet\3';
+W4 = 'E:\Batch\5B\T6Wet\4';
+W5 = 'E:\Batch\5B\T6Wet\5';
+W6 = 'E:\Batch\5B\T6Wet\6';
+W7 = 'E:\Batch\5B\T6Wet\7';
+WCS = imageDatastore(WC);
+W1S = imageDatastore(W1);
+W2S = imageDatastore(W2);
+W3S = imageDatastore(W3);
+W4S = imageDatastore(W4);
+W5S = imageDatastore(W5);
+W6S = imageDatastore(W6);
+W7S = imageDatastore(W7);
+W0R = batchR(WCS);
+W1R = batchR(W1S);
+W2R = batchR(W2S);
+W3R = batchR(W3S);
+W4R = batchR(W4S);
+W5R = batchR(W5S);
+W6R = batchR(W6S);
+W7R = batchR(W7S);
+
+W0G = batchG(WCS);
+W1G = batchG(W1S);
+W2G = batchG(W2S);
+W3G = batchG(W3S);
+W4G = batchG(W4S);
+W5B = batchG(W5S);
+W6G = batchG(W6S);
+W7G = batchG(W7S);
+
+W0B = batchB(WCS);
+W1B = batchB(W1S);
+W2B = batchB(W2S);
+W3B = batchB(W3S);
+W4B = batchB(W4S);
+W5B = batchB(W5S);
+W6B = batchB(W6S);
+W7B = batchB(W7S);
+
+WRG0 = [W0R;W0G];
+WRG1 = [W1R;W1G];
+WRG2 = [W2R;W2G];
+WRG3 = [W3R;W3G];
+WRG4 = [W4R;W4G];
+WRG5 = [W5R;W5B];
+WRG6 = [W6R;W6G];
+WRG7 = [W7R;W7G];
+
+WRB0 = [W0R;W0B];
+WRB1 = [W1R;W1B];
+WRB2 = [W2R;W2B];
+WRB3 = [W3R;W3B];
+WRB4 = [W4R;W4B];
+WRB5 = [W5R;W5B];
+WRB6 = [W6R;W6B];
+WRB7 = [W7R;W7B];
+
+WGB0 = [W0G;W0B];
+WGB1 = [W1G;W1B];
+WGB2 = [W2G;W2B];
+WGB3 = [W3G;W3B];
+WGB4 = [W4G;W4B];
+WGB5 = [W5B;W5B];
+WGB6 = [W6G;W6B];
+WGB7 = [W7G;W7B];
+
+WDTW0RG = one(MCRG,WRG0);
+WDTW1RG = one(MCRG,WRG1);
+WDTW2RG = one(MCRG,WRG2);
+WDTW3RG = one(MCRG,WRG3);
+WDTW4RG = one(MCRG,WRG4);
+WDTW5RG = one(MCRG,WRG5);
+WDTW6RG = one(MCRG,WRG6);
+WDTW7RG = one(MCRG,WRG7);
+
+WDTW0RB = one(MCRB,WRB0);
+WDTW1RB = one(MCRB,WRB1);
+WDTW2RB = one(MCRB,WRB2);
+WDTW3RB = one(MCRB,WRB3);
+WDTW4RB = one(MCRB,WRB4);
+WDTW5RB = one(MCRB,WRB5);
+WDTW6RB = one(MCRB,WRB6);
+WDTW7RB = one(MCRB,WRB7);
+
+WDTW0GB = one(MCGB,WGB0);
+WDTW1GB = one(MCGB,WGB1);
+WDTW2GB = one(MCGB,WGB2);
+WDTW3GB = one(MCGB,WGB3);
+WDTW4GB = one(MCGB,WGB4);
+WDTW5BB = one(MCGB,WGB5);
+WDTW6GB = one(MCGB,WGB6);
+WDTW7GB = one(MCGB,WGB7);
+
+WDTWGB = [WDTW0GB(:,1); WDTW1GB(:,1); WDTW2GB(:,1); WDTW3GB(:,1); WDTW4GB(:,1); WDTW5BB(:,1); WDTW6GB(:,1); WDTW7GB(:,1)];
+WDTWRG = [WDTW0RG(:,1); WDTW1RG(:,1); WDTW2RG(:,1); WDTW3RG(:,1); WDTW4RG(:,1); WDTW5RG(:,1); WDTW6RG(:,1); WDTW7RG(:,1)];
+Wone = [WDTW0RB(:,1); WDTW1RB(:,1); WDTW2RB(:,1); WDTW3RB(:,1); WDTW4RB(:,1); WDTW5RB(:,1); WDTW6RB(:,1); WDTW7RB(:,1)];
+
+%Dry - Trial 7
+DC = 'E:\Batch\5B\T7Dry\0';
+D1 = 'E:\Batch\5B\T7Dry\1';
+D2 = 'E:\Batch\5B\T7Dry\2';
+D3 = 'E:\Batch\5B\T7Dry\3';
+D4 = 'E:\Batch\5B\T7Dry\4';
+D5 = 'E:\Batch\5B\T7Dry\5';
+D6 = 'E:\Batch\5B\T7Dry\6';
+D7 = 'E:\Batch\5B\T7Dry\7';
+DCS = imageDatastore(DC);
+D1S = imageDatastore(D1);
+D2S = imageDatastore(D2);
+D3S = imageDatastore(D3);
+D4S = imageDatastore(D4);
+D5S = imageDatastore(D5);
+D6S = imageDatastore(D6);
+D7S = imageDatastore(D7);
+D0R = batchR(DCS);
+D1R = batchR(D1S);
+D2R = batchR(D2S);
+D3R = batchR(D3S);
+D4R = batchR(D4S);
+D5R = batchR(D5S);
+D6R = batchR(D6S);
+D7R = batchR(D7S);
+
+D0G = batchG(DCS);
+D1G = batchG(D1S);
+D2G = batchG(D2S);
+D3G = batchG(D3S);
+D4G = batchG(D4S);
+D5B = batchG(D5S);
+D6G = batchG(D6S);
+D7G = batchG(D7S);
+
+D0B = batchB(DCS);
+D1B = batchB(D1S);
+D2B = batchB(D2S);
+D3B = batchB(D3S);
+D4B = batchB(D4S);
+D5B = batchB(D5S);
+D6B = batchB(D6S);
+D7B = batchB(D7S);
+
+DRG0 = [D0R;D0G];
+DRG1 = [D1R;D1G];
+DRG2 = [D2R;D2G];
+DRG3 = [D3R;D3G];
+DRG4 = [D4R;D4G];
+DRG5 = [D5R;D5B];
+DRG6 = [D6R;D6G];
+DRG7 = [D7R;D7G];
+
+DRB0 = [D0R;D0B];
+DRB1 = [D1R;D1B];
+DRB2 = [D2R;D2B];
+DRB3 = [D3R;D3B];
+DRB4 = [D4R;D4B];
+DRB5 = [D5R;D5B];
+DRB6 = [D6R;D6B];
+DRB7 = [D7R;D7B];
+
+DGB0 = [D0G;D0B];
+DGB1 = [D1G;D1B];
+DGB2 = [D2G;D2B];
+DGB3 = [D3G;D3B];
+DGB4 = [D4G;D4B];
+DGB5 = [D5B;D5B];
+DGB6 = [D6G;D6B];
+DGB7 = [D7G;D7B];
+
+DDTW0RG = one(MCRG,DRG0);
+DDTW1RG = one(MCRG,DRG1);
+DDTW2RG = one(MCRG,DRG2);
+DDTW3RG = one(MCRG,DRG3);
+DDTW4RG = one(MCRG,DRG4);
+DDTW5RG = one(MCRG,DRG5);
+DDTW6RG = one(MCRG,DRG6);
+DDTW7RG = one(MCRG,DRG7);
+
+DDTW0RB = one(MCRB,DRB0);
+DDTW1RB = one(MCRB,DRB1);
+DDTW2RB = one(MCRB,DRB2);
+DDTW3RB = one(MCRB,DRB3);
+DDTW4RB = one(MCRB,DRB4);
+DDTW5RB = one(MCRB,DRB5);
+DDTW6RB = one(MCRB,DRB6);
+DDTW7RB = one(MCRB,DRB7);
+
+DDTW0GB = one(MCGB,DGB0);
+DDTW1GB = one(MCGB,DGB1);
+DDTW2GB = one(MCGB,DGB2);
+DDTW3GB = one(MCGB,DGB3);
+DDTW4GB = one(MCGB,DGB4);
+DDTW5BB = one(MCGB,DGB5);
+DDTW6GB = one(MCGB,DGB6);
+DDTW7GB = one(MCGB,DGB7);
+
+DDTWGB = [DDTW0GB(:,1); DDTW1GB(:,1); DDTW2GB(:,1); DDTW3GB(:,1); DDTW4GB(:,1); DDTW5BB(:,1); DDTW6GB(:,1); DDTW7GB(:,1)];
+DDTWRG = [DDTW0RG(:,1); DDTW1RG(:,1); DDTW2RG(:,1); DDTW3RG(:,1); DDTW4RG(:,1); DDTW5RG(:,1); DDTW6RG(:,1); DDTW7RG(:,1)];
+Done = [DDTW0RB(:,1); DDTW1RB(:,1); DDTW2RB(:,1); DDTW3RB(:,1); DDTW4RB(:,1); DDTW5RB(:,1); DDTW6RB(:,1); DDTW7RB(:,1)];
+
+%Nutrients - Trial 8
+NC = 'E:\Batch\5B\T8Nut\0';
+N1 = 'E:\Batch\5B\T8Nut\1';
+N2 = 'E:\Batch\5B\T8Nut\2';
+N3 = 'E:\Batch\5B\T8Nut\3';
+N4 = 'E:\Batch\5B\T8Nut\4';
+N5 = 'E:\Batch\5B\T8Nut\5';
+N6 = 'E:\Batch\5B\T8Nut\6';
+N7 = 'E:\Batch\5B\T8Nut\7';
+NCS = imageDatastore(NC);
+N1S = imageDatastore(N1);
+N2S = imageDatastore(N2);
+N3S = imageDatastore(N3);
+N4S = imageDatastore(N4);
+N5S = imageDatastore(N5);
+N6S = imageDatastore(N6);
+N7S = imageDatastore(N7);
+N0R = batchR(NCS);
+N1R = batchR(N1S);
+N2R = batchR(N2S);
+N3R = batchR(N3S);
+N4R = batchR(N4S);
+N5R = batchR(N5S);
+N6R = batchR(N6S);
+N7R = batchR(N7S);
+
+N0G = batchG(NCS);
+N1G = batchG(N1S);
+N2G = batchG(N2S);
+N3G = batchG(N3S);
+N4G = batchG(N4S);
+N5B = batchG(N5S);
+N6G = batchG(N6S);
+N7G = batchG(N7S);
+
+N0B = batchB(NCS);
+N1B = batchB(N1S);
+N2B = batchB(N2S);
+N3B = batchB(N3S);
+N4B = batchB(N4S);
+N5B = batchB(N5S);
+N6B = batchB(N6S);
+N7B = batchB(N7S);
+
+NRG0 = [N0R;N0G];
+NRG1 = [N1R;N1G];
+NRG2 = [N2R;N2G];
+NRG3 = [N3R;N3G];
+NRG4 = [N4R;N4G];
+NRG5 = [N5R;N5B];
+NRG6 = [N6R;N6G];
+NRG7 = [N7R;N7G];
+
+NRB0 = [N0R;N0B];
+NRB1 = [N1R;N1B];
+NRB2 = [N2R;N2B];
+NRB3 = [N3R;N3B];
+NRB4 = [N4R;N4B];
+NRB5 = [N5R;N5B];
+NRB6 = [N6R;N6B];
+NRB7 = [N7R;N7B];
+
+NGB0 = [N0G;N0B];
+NGB1 = [N1G;N1B];
+NGB2 = [N2G;N2B];
+NGB3 = [N3G;N3B];
+NGB4 = [N4G;N4B];
+NGB5 = [N5B;N5B];
+NGB6 = [N6G;N6B];
+NGB7 = [N7G;N7B];
+
+NDTW0RG = one(MCRG,NRG0);
+NDTW1RG = one(MCRG,NRG1);
+NDTW2RG = one(MCRG,NRG2);
+NDTW3RG = one(MCRG,NRG3);
+NDTW4RG = one(MCRG,NRG4);
+NDTW5RG = one(MCRG,NRG5);
+NDTW6RG = one(MCRG,NRG6);
+NDTW7RG = one(MCRG,NRG7);
+
+NDTW0RB = one(MCRB,NRB0);
+NDTW1RB = one(MCRB,NRB1);
+NDTW2RB = one(MCRB,NRB2);
+NDTW3RB = one(MCRB,NRB3);
+NDTW4RB = one(MCRB,NRB4);
+NDTW5RB = one(MCRB,NRB5);
+NDTW6RB = one(MCRB,NRB6);
+NDTW7RB = one(MCRB,NRB7);
+
+NDTW0GB = one(MCGB,NGB0);
+NDTW1GB = one(MCGB,NGB1);
+NDTW2GB = one(MCGB,NGB2);
+NDTW3GB = one(MCGB,NGB3);
+NDTW4GB = one(MCGB,NGB4);
+NDTW5BB = one(MCGB,NGB5);
+NDTW6GB = one(MCGB,NGB6);
+NDTW7GB = one(MCGB,NGB7);
+
+NDTWGB = [NDTW0GB(:,1); NDTW1GB(:,1); NDTW2GB(:,1); NDTW3GB(:,1); NDTW4GB(:,1); NDTW5BB(:,1); NDTW6GB(:,1); NDTW7GB(:,1)];
+NDTWRG = [NDTW0RG(:,1); NDTW1RG(:,1); NDTW2RG(:,1); NDTW3RG(:,1); NDTW4RG(:,1); NDTW5RG(:,1); NDTW6RG(:,1); NDTW7RG(:,1)];
+None = [NDTW0RB(:,1); NDTW1RB(:,1); NDTW2RB(:,1); NDTW3RB(:,1); NDTW4RB(:,1); NDTW5RB(:,1); NDTW6RB(:,1); NDTW7RB(:,1)];
+
+%Long - Trial 9
+LC = 'E:\Batch\5B\T9Long\0';
+L1 = 'E:\Batch\5B\T9Long\1';
+L2 = 'E:\Batch\5B\T9Long\2';
+L3 = 'E:\Batch\5B\T9Long\3';
+L4 = 'E:\Batch\5B\T9Long\4';
+L5 = 'E:\Batch\5B\T9Long\5';
+L6 = 'E:\Batch\5B\T9Long\6';
+L7 = 'E:\Batch\5B\T9Long\7';
+LCS = imageDatastore(LC);
+L1S = imageDatastore(L1);
+L2S = imageDatastore(L2);
+L3S = imageDatastore(L3);
+L4S = imageDatastore(L4);
+L5S = imageDatastore(L5);
+L6S = imageDatastore(L6);
+L7S = imageDatastore(L7);
+L0R = batchR(LCS);
+L1R = batchR(L1S);
+L2R = batchR(L2S);
+L3R = batchR(L3S);
+L4R = batchR(L4S);
+L5R = batchR(L5S);
+L6R = batchR(L6S);
+L7R = batchR(L7S);
+
+L0G = batchG(LCS);
+L1G = batchG(L1S);
+L2G = batchG(L2S);
+L3G = batchG(L3S);
+L4G = batchG(L4S);
+L5B = batchG(L5S);
+L6G = batchG(L6S);
+L7G = batchG(L7S);
+
+L0B = batchB(LCS);
+L1B = batchB(L1S);
+L2B = batchB(L2S);
+L3B = batchB(L3S);
+L4B = batchB(L4S);
+L5B = batchB(L5S);
+L6B = batchB(L6S);
+L7B = batchB(L7S);
+
+LRG0 = [L0R;L0G];
+LRG1 = [L1R;L1G];
+LRG2 = [L2R;L2G];
+LRG3 = [L3R;L3G];
+LRG4 = [L4R;L4G];
+LRG5 = [L5R;L5B];
+LRG6 = [L6R;L6G];
+LRG7 = [L7R;L7G];
+
+LRB0 = [L0R;L0B];
+LRB1 = [L1R;L1B];
+LRB2 = [L2R;L2B];
+LRB3 = [L3R;L3B];
+LRB4 = [L4R;L4B];
+LRB5 = [L5R;L5B];
+LRB6 = [L6R;L6B];
+LRB7 = [L7R;L7B];
+
+LGB0 = [L0G;L0B];
+LGB1 = [L1G;L1B];
+LGB2 = [L2G;L2B];
+LGB3 = [L3G;L3B];
+LGB4 = [L4G;L4B];
+LGB5 = [L5B;L5B];
+LGB6 = [L6G;L6B];
+LGB7 = [L7G;L7B];
+
+LDTW0RG = one(MCRG,LRG0);
+LDTW1RG = one(MCRG,LRG1);
+LDTW2RG = one(MCRG,LRG2);
+LDTW3RG = one(MCRG,LRG3);
+LDTW4RG = one(MCRG,LRG4);
+LDTW5RG = one(MCRG,LRG5);
+LDTW6RG = one(MCRG,LRG6);
+LDTW7RG = one(MCRG,LRG7);
+
+LDTW0RB = one(MCRB,LRB0);
+LDTW1RB = one(MCRB,LRB1);
+LDTW2RB = one(MCRB,LRB2);
+LDTW3RB = one(MCRB,LRB3);
+LDTW4RB = one(MCRB,LRB4);
+LDTW5RB = one(MCRB,LRB5);
+LDTW6RB = one(MCRB,LRB6);
+LDTW7RB = one(MCRB,LRB7);
+
+LDTW0GB = one(MCGB,LGB0);
+LDTW1GB = one(MCGB,LGB1);
+LDTW2GB = one(MCGB,LGB2);
+LDTW3GB = one(MCGB,LGB3);
+LDTW4GB = one(MCGB,LGB4);
+LDTW5BB = one(MCGB,LGB5);
+LDTW6GB = one(MCGB,LGB6);
+LDTW7GB = one(MCGB,LGB7);
+
+LDTWGB = [LDTW0GB(:,1); LDTW1GB(:,1); LDTW2GB(:,1); LDTW3GB(:,1); LDTW4GB(:,1); LDTW5BB(:,1); LDTW6GB(:,1); LDTW7GB(:,1)];
+LDTWRG = [LDTW0RG(:,1); LDTW1RG(:,1); LDTW2RG(:,1); LDTW3RG(:,1); LDTW4RG(:,1); LDTW5RG(:,1); LDTW6RG(:,1); LDTW7RG(:,1)];
+Lone = [LDTW0RB(:,1); LDTW1RB(:,1); LDTW2RB(:,1); LDTW3RB(:,1); LDTW4RB(:,1); LDTW5RB(:,1); LDTW6RB(:,1); LDTW7RB(:,1)];
+
+%Short - Trial 10
+SC = 'E:\Batch\5B\T10Shrt\0';
+S1 = 'E:\Batch\5B\T10Shrt\1';
+S2 = 'E:\Batch\5B\T10Shrt\2';
+S3 = 'E:\Batch\5B\T10Shrt\3';
+S4 = 'E:\Batch\5B\T10Shrt\4';
+S5 = 'E:\Batch\5B\T10Shrt\5';
+S6 = 'E:\Batch\5B\T10Shrt\6';
+S7 = 'E:\Batch\5B\T10Shrt\7';
+SCS = imageDatastore(SC);
+S1S = imageDatastore(S1);
+S2S = imageDatastore(S2);
+S3S = imageDatastore(S3);
+S4S = imageDatastore(S4);
+S5S = imageDatastore(S5);
+S6S = imageDatastore(S6);
+S7S = imageDatastore(S7);
+S0R = batchR(SCS);
+S1R = batchR(S1S);
+S2R = batchR(S2S);
+S3R = batchR(S3S);
+S4R = batchR(S4S);
+S5R = batchR(S5S);
+S6R = batchR(S6S);
+S7R = batchR(S7S);
+
+S0G = batchG(SCS);
+S1G = batchG(S1S);
+S2G = batchG(S2S);
+S3G = batchG(S3S);
+S4G = batchG(S4S);
+S5B = batchG(S5S);
+S6G = batchG(S6S);
+S7G = batchG(S7S);
+
+S0B = batchB(SCS);
+S1B = batchB(S1S);
+S2B = batchB(S2S);
+S3B = batchB(S3S);
+S4B = batchB(S4S);
+S5B = batchB(S5S);
+S6B = batchB(S6S);
+S7B = batchB(S7S);
+
+SRG0 = [S0R;S0G];
+SRG1 = [S1R;S1G];
+SRG2 = [S2R;S2G];
+SRG3 = [S3R;S3G];
+SRG4 = [S4R;S4G];
+SRG5 = [S5R;S5B];
+SRG6 = [S6R;S6G];
+SRG7 = [S7R;S7G];
+
+SRB0 = [S0R;S0B];
+SRB1 = [S1R;S1B];
+SRB2 = [S2R;S2B];
+SRB3 = [S3R;S3B];
+SRB4 = [S4R;S4B];
+SRB5 = [S5R;S5B];
+SRB6 = [S6R;S6B];
+SRB7 = [S7R;S7B];
+
+SGB0 = [S0G;S0B];
+SGB1 = [S1G;S1B];
+SGB2 = [S2G;S2B];
+SGB3 = [S3G;S3B];
+SGB4 = [S4G;S4B];
+SGB5 = [S5B;S5B];
+SGB6 = [S6G;S6B];
+SGB7 = [S7G;S7B];
+
+SDTW0RG = one(MCRG,SRG0);
+SDTW1RG = one(MCRG,SRG1);
+SDTW2RG = one(MCRG,SRG2);
+SDTW3RG = one(MCRG,SRG3);
+SDTW4RG = one(MCRG,SRG4);
+SDTW5RG = one(MCRG,SRG5);
+SDTW6RG = one(MCRG,SRG6);
+SDTW7RG = one(MCRG,SRG7);
+
+SDTW0RB = one(MCRB,SRB0);
+SDTW1RB = one(MCRB,SRB1);
+SDTW2RB = one(MCRB,SRB2);
+SDTW3RB = one(MCRB,SRB3);
+SDTW4RB = one(MCRB,SRB4);
+SDTW5RB = one(MCRB,SRB5);
+SDTW6RB = one(MCRB,SRB6);
+SDTW7RB = one(MCRB,SRB7);
+
+SDTW0GB = one(MCGB,SGB0);
+SDTW1GB = one(MCGB,SGB1);
+SDTW2GB = one(MCGB,SGB2);
+SDTW3GB = one(MCGB,SGB3);
+SDTW4GB = one(MCGB,SGB4);
+SDTW5BB = one(MCGB,SGB5);
+SDTW6GB = one(MCGB,SGB6);
+SDTW7GB = one(MCGB,SGB7);
+
+SDTWGB = [SDTW0GB(:,1); SDTW1GB(:,1); SDTW2GB(:,1); SDTW3GB(:,1); SDTW4GB(:,1); SDTW5BB(:,1); SDTW6GB(:,1); SDTW7GB(:,1)];
+SDTWRG = [SDTW0RG(:,1); SDTW1RG(:,1); SDTW2RG(:,1); SDTW3RG(:,1); SDTW4RG(:,1); SDTW5RG(:,1); SDTW6RG(:,1); SDTW7RG(:,1)];
+Sone = [SDTW0RB(:,1); SDTW1RB(:,1); SDTW2RB(:,1); SDTW3RB(:,1); SDTW4RB(:,1); SDTW5RB(:,1); SDTW6RB(:,1); SDTW7RB(:,1)];
+
+%Dark - Trial 11
+AC = 'E:\Batch\5B\T11Dark\0';
+A1 = 'E:\Batch\5B\T11Dark\1';
+A2 = 'E:\Batch\5B\T11Dark\2';
+A3 = 'E:\Batch\5B\T11Dark\3';
+A4 = 'E:\Batch\5B\T11Dark\4';
+A5 = 'E:\Batch\5B\T11Dark\5';
+A6 = 'E:\Batch\5B\T11Dark\6';
+A7 = 'E:\Batch\5B\T11Dark\7';
+ACS = imageDatastore(AC);
+A1S = imageDatastore(A1);
+A2S = imageDatastore(A2);
+A3S = imageDatastore(A3);
+A4S = imageDatastore(A4);
+A5S = imageDatastore(A5);
+A6S = imageDatastore(A6);
+A7S = imageDatastore(A7);
+A0R = batchR(ACS);
+A1R = batchR(A1S);
+A2R = batchR(A2S);
+A3R = batchR(A3S);
+A4R = batchR(A4S);
+A5R = batchR(A5S);
+A6R = batchR(A6S);
+A7R = batchR(A7S);
+
+A0G = batchG(ACS);
+A1G = batchG(A1S);
+A2G = batchG(A2S);
+A3G = batchG(A3S);
+A4G = batchG(A4S);
+A5B = batchG(A5S);
+A6G = batchG(A6S);
+A7G = batchG(A7S);
+
+A0B = batchB(ACS);
+A1B = batchB(A1S);
+A2B = batchB(A2S);
+A3B = batchB(A3S);
+A4B = batchB(A4S);
+A5B = batchB(A5S);
+A6B = batchB(A6S);
+A7B = batchB(A7S);
+
+ARG0 = [A0R;A0G];
+ARG1 = [A1R;A1G];
+ARG2 = [A2R;A2G];
+ARG3 = [A3R;A3G];
+ARG4 = [A4R;A4G];
+ARG5 = [A5R;A5B];
+ARG6 = [A6R;A6G];
+ARG7 = [A7R;A7G];
+
+ARB0 = [A0R;A0B];
+ARB1 = [A1R;A1B];
+ARB2 = [A2R;A2B];
+ARB3 = [A3R;A3B];
+ARB4 = [A4R;A4B];
+ARB5 = [A5R;A5B];
+ARB6 = [A6R;A6B];
+ARB7 = [A7R;A7B];
+
+AGB0 = [A0G;A0B];
+AGB1 = [A1G;A1B];
+AGB2 = [A2G;A2B];
+AGB3 = [A3G;A3B];
+AGB4 = [A4G;A4B];
+AGB5 = [A5B;A5B];
+AGB6 = [A6G;A6B];
+AGB7 = [A7G;A7B];
+
+ADTW0RG = one(MCRG,ARG0);
+ADTW1RG = one(MCRG,ARG1);
+ADTW2RG = one(MCRG,ARG2);
+ADTW3RG = one(MCRG,ARG3);
+ADTW4RG = one(MCRG,ARG4);
+ADTW5RG = one(MCRG,ARG5);
+ADTW6RG = one(MCRG,ARG6);
+ADTW7RG = one(MCRG,ARG7);
+
+ADTW0RB = one(MCRB,ARB0);
+ADTW1RB = one(MCRB,ARB1);
+ADTW2RB = one(MCRB,ARB2);
+ADTW3RB = one(MCRB,ARB3);
+ADTW4RB = one(MCRB,ARB4);
+ADTW5RB = one(MCRB,ARB5);
+ADTW6RB = one(MCRB,ARB6);
+ADTW7RB = one(MCRB,ARB7);
+
+ADTW0GB = one(MCGB,AGB0);
+ADTW1GB = one(MCGB,AGB1);
+ADTW2GB = one(MCGB,AGB2);
+ADTW3GB = one(MCGB,AGB3);
+ADTW4GB = one(MCGB,AGB4);
+ADTW5BB = one(MCGB,AGB5);
+ADTW6GB = one(MCGB,AGB6);
+ADTW7GB = one(MCGB,AGB7);
+
+ADTWGB = [ADTW0GB(:,1); ADTW1GB(:,1); ADTW2GB(:,1); ADTW3GB(:,1); ADTW4GB(:,1); ADTW5BB(:,1); ADTW6GB(:,1); ADTW7GB(:,1)];
+ADTWRG = [ADTW0RG(:,1); ADTW1RG(:,1); ADTW2RG(:,1); ADTW3RG(:,1); ADTW4RG(:,1); ADTW5RG(:,1); ADTW6RG(:,1); ADTW7RG(:,1)];
+Aone = [ADTW0RB(:,1); ADTW1RB(:,1); ADTW2RB(:,1); ADTW3RB(:,1); ADTW4RB(:,1); ADTW5RB(:,1); ADTW6RB(:,1); ADTW7RB(:,1)];
+
+x = (0:7);
+figure;
+plot(x,CuDTWGB,'LineWidth',2);
+hold on
+plot(x,ZnDTWGB,'LineWidth',2);
+plot(x,PbDTWGB,'LineWidth',2);
+plot(x,MDTWGB,'LineWidth',2);
+%plot(x,crmean);
+%yline(Mmean,'k');
+%yline(Mstd2pos,'k--');
+%yline(Mstd3pos,'k:');
+yline(ContMb,'k','LineWidth',2);
+yline(Contstd2b,'k--','LineWidth',2);
+yline(Contstd3b,'k:','LineWidth',2);
+%legend('Cu','Zn','Pb','Mix','Mean','2\sigma','3\sigma');
+set(gca,'fontname','arial','fontsize',18,'fontweight','bold');
+xlabel('Time(days)')
+%ylabel('DTW')
+axis([0 7 .1 .7]);
+hold off
+
+%red
+figure;
+plot(x,Cuone,'LineWidth',2);
+hold on
+plot(x,Znone,'LineWidth',2);
+plot(x,Pbone,'LineWidth',2);
+plot(x,Mone,'LineWidth',2);
+%plot(x,crmean);
+%yline(Mmean,'k');
+%yline(Mstd2pos,'k--');
+%yline(Mstd3pos,'k:');
+yline(ContM,'k','LineWidth',2);
+yline(Contstd2,'k--','LineWidth',2);
+yline(Contstd3,'k:','LineWidth',2);
+%legend('Cu','Zn','Pb','Mix','Mean','2\sigma','3\sigma');
+set(gca,'fontname','arial','fontsize',18,'fontweight','bold');
+xlabel('Time(days)')
+%ylabel('DTW')
+axis([0 7 .1 .7]);
+hold off
+
+%green
+figure;
+plot(x,CuDTWRG,'LineWidth',2);
+hold on
+plot(x,ZnDTWRG,'LineWidth',2);
+plot(x,PbDTWRG,'LineWidth',2);
+plot(x,MDTWRG,'LineWidth',2);
+%plot(x,crmean);
+%yline(Mmean,'k');
+%yline(Mstd2pos,'k--');
+%yline(Mstd3pos,'k:');
+yline(ContMg,'k','LineWidth',2);
+yline(Contstd2g,'k--','LineWidth',2);
+yline(Contstd3g,'k:','LineWidth',2);
+%legend('Cu','Zn','Pb','Mix','Mean','2\sigma','3\sigma');
+set(gca,'fontname','arial','fontsize',18,'fontweight','bold');
+xlabel('Time(days)')
+%ylabel('DTW')
+axis([0 7 .1 .7]);
+hold off
+
+%ALL figure thing
+figure;
+plot(x,CuDTWGB);
+hold on
+plot(x,ZnDTWGB);
+plot(x,PbDTWGB);
+plot(x,MDTWGB);
+plot(x,CDTWGB);
+plot(x,WDTWGB);
+plot(x,DDTWGB);
+plot(x,NDTWGB);
+plot(x,LDTWGB);
+plot(x,SDTWGB);
+plot(x,ADTWGB);
+legend('Cu','Zn','Pb','Mix','Cont','Wet','Dry','Nutr','Long','Short','Dark');
+yline(Mmean,'k');
+yline(Mstd2pos,'k--');
+yline(Mstd3pos,'k:');
+yline(Mstd2neg,'k--');
+yline(Mstd3neg,'k:');
+hold off

--- a/Batch_dtwS_E_B.m
+++ b/Batch_dtwS_E_B.m
@@ -1,0 +1,1209 @@
+%This code is for just running the dtw comparisons for single color
+
+MasterC = 'E:\Batch\5B\Control';
+MasterCS = imageDatastore(MasterC);
+MCR = batchMR(MasterCS);
+MSR = batchR(MasterCS);
+
+%need make function for batch process
+%DTW1 = dtw(MCR,Cu0R(:,15));
+%DTW2 = dtw2(MCR,Cu0R(:,1),(MCR-Cu0R(:,1)));
+
+%copper trial 1
+CuC = 'E:\Batch\5B\T1Cu\0';
+Cu1 = 'E:\Batch\5B\T1Cu\1';
+Cu2 = 'E:\Batch\5B\T1Cu\2';
+Cu3 = 'E:\Batch\5B\T1Cu\3';
+Cu4 = 'E:\Batch\5B\T1Cu\4';
+Cu5 = 'E:\Batch\5B\T1Cu\5';
+Cu6 = 'E:\Batch\5B\T1Cu\6';
+Cu7 = 'E:\Batch\5B\T1Cu\7';
+CuCS = imageDatastore(CuC);
+Cu1S = imageDatastore(Cu1);
+Cu2S = imageDatastore(Cu2);
+Cu3S = imageDatastore(Cu3);
+Cu4S = imageDatastore(Cu4);
+Cu5S = imageDatastore(Cu5);
+Cu6S = imageDatastore(Cu6);
+Cu7S = imageDatastore(Cu7);
+
+Cu0R = batchR(CuCS);
+Cu1R = batchR(Cu1S);
+Cu2R = batchR(Cu2S);
+Cu3R = batchR(Cu3S);
+Cu4R = batchR(Cu4S);
+Cu5R = batchR(Cu5S);
+Cu6R = batchR(Cu6S);
+Cu7R = batchR(Cu7S);
+
+CuDTW0R = one(MSR,Cu0R);
+CuDTW1R = one(MSR,Cu1R);
+CuDTW2R = one(MSR,Cu2R);
+CuDTW3R = one(MSR,Cu3R);
+CuDTW4R = one(MSR,Cu4R);
+CuDTW5R = one(MSR,Cu5R);
+CuDTW6R = one(MSR,Cu6R);
+CuDTW7R = one(MSR,Cu7R);
+
+CuDTWR = [CuDTW0R(:,1); CuDTW1R(:,1); CuDTW2R(:,1); CuDTW3R(:,1); CuDTW4R(:,1); CuDTW5R(:,1); CuDTW6R(:,1); CuDTW7R(:,1)];
+CuDTWRstd2 = [CuDTW0R(:,2); CuDTW1R(:,2); CuDTW2R(:,2); CuDTW3R(:,2); CuDTW4R(:,2); CuDTW5R(:,2); CuDTW6R(:,2); CuDTW7R(:,2)];
+CuDTWRstd3 = [CuDTW0R(:,3); CuDTW1R(:,3); CuDTW2R(:,3); CuDTW3R(:,3); CuDTW4R(:,3); CuDTW5R(:,3); CuDTW6R(:,3); CuDTW7R(:,3)];
+
+%zinc trial 2
+ZnC = 'E:\Batch\5B\T2Zn\0';
+Zn1 = 'E:\Batch\5B\T2Zn\1';
+Zn2 = 'E:\Batch\5B\T2Zn\2';
+Zn3 = 'E:\Batch\5B\T2Zn\3';
+Zn4 = 'E:\Batch\5B\T2Zn\4';
+Zn5 = 'E:\Batch\5B\T2Zn\5';
+Zn6 = 'E:\Batch\5B\T2Zn\6';
+Zn7 = 'E:\Batch\5B\T2Zn\7';
+ZnCS = imageDatastore(ZnC);
+Zn1S = imageDatastore(Zn1);
+Zn2S = imageDatastore(Zn2);
+Zn3S = imageDatastore(Zn3);
+Zn4S = imageDatastore(Zn4);
+Zn5S = imageDatastore(Zn5);
+Zn6S = imageDatastore(Zn6);
+Zn7S = imageDatastore(Zn7);
+
+Zn0R = batchR(ZnCS);
+Zn1R = batchR(Zn1S);
+Zn2R = batchR(Zn2S);
+Zn3R = batchR(Zn3S);
+Zn4R = batchR(Zn4S);
+Zn5R = batchR(Zn5S);
+Zn6R = batchR(Zn6S);
+Zn7R = batchR(Zn7S);
+
+ZnDTW0R = one(MSR,Zn0R);
+ZnDTW1R = one(MSR,Zn1R);
+ZnDTW2R = one(MSR,Zn2R);
+ZnDTW3R = one(MSR,Zn3R);
+ZnDTW4R = one(MSR,Zn4R);
+ZnDTW5R = one(MSR,Zn5R);
+ZnDTW6R = one(MSR,Zn6R);
+ZnDTW7R = one(MSR,Zn7R);
+
+ZnDTWR = [ZnDTW0R(:,1); ZnDTW1R(:,1); ZnDTW2R(:,1); ZnDTW3R(:,1); ZnDTW4R(:,1); ZnDTW5R(:,1); ZnDTW6R(:,1); ZnDTW7R(:,1)];
+ZnDTWRstd2 = [ZnDTW0R(:,2); ZnDTW1R(:,2); ZnDTW2R(:,2); ZnDTW3R(:,2); ZnDTW4R(:,2); ZnDTW5R(:,2); ZnDTW6R(:,2); ZnDTW7R(:,2)];
+ZnDTWRstd3 = [ZnDTW0R(:,3); ZnDTW1R(:,3); ZnDTW2R(:,3); ZnDTW3R(:,3); ZnDTW4R(:,3); ZnDTW5R(:,3); ZnDTW6R(:,3); ZnDTW7R(:,3)];
+
+%lead trial 3
+PbC = 'E:\Batch\5B\T3Pb\0';
+Pb1 = 'E:\Batch\5B\T3Pb\1';
+Pb2 = 'E:\Batch\5B\T3Pb\2';
+Pb3 = 'E:\Batch\5B\T3Pb\3';
+Pb4 = 'E:\Batch\5B\T3Pb\4';
+Pb5 = 'E:\Batch\5B\T3Pb\5';
+Pb6 = 'E:\Batch\5B\T3Pb\6';
+Pb7 = 'E:\Batch\5B\T3Pb\7';
+PbCS = imageDatastore(PbC);
+Pb1S = imageDatastore(Pb1);
+Pb2S = imageDatastore(Pb2);
+Pb3S = imageDatastore(Pb3);
+Pb4S = imageDatastore(Pb4);
+Pb5S = imageDatastore(Pb5);
+Pb6S = imageDatastore(Pb6);
+Pb7S = imageDatastore(Pb7);
+Pb0R = batchR(PbCS);
+Pb1R = batchR(Pb1S);
+Pb2R = batchR(Pb2S);
+Pb3R = batchR(Pb3S);
+Pb4R = batchR(Pb4S);
+Pb5R = batchR(Pb5S);
+Pb6R = batchR(Pb6S);
+Pb7R = batchR(Pb7S);
+
+PbDTW0R = one(MSR,Pb0R);
+PbDTW1R = one(MSR,Pb1R);
+PbDTW2R = one(MSR,Pb2R);
+PbDTW3R = one(MSR,Pb3R);
+PbDTW4R = one(MSR,Pb4R);
+PbDTW5R = one(MSR,Pb5R);
+PbDTW6R = one(MSR,Pb6R);
+PbDTW7R = one(MSR,Pb7R);
+
+PbDTWR = [PbDTW0R(:,1); PbDTW1R(:,1); PbDTW2R(:,1); PbDTW3R(:,1); PbDTW4R(:,1); PbDTW5R(:,1); PbDTW6R(:,1); PbDTW7R(:,1)];
+PbDTWRstd2 = [PbDTW0R(:,2); PbDTW1R(:,2); PbDTW2R(:,2); PbDTW3R(:,2); PbDTW4R(:,2); PbDTW5R(:,2); PbDTW6R(:,2); PbDTW7R(:,2)];
+PbDTWRstd3 = [PbDTW0R(:,3); PbDTW1R(:,3); PbDTW2R(:,3); PbDTW3R(:,3); PbDTW4R(:,3); PbDTW5R(:,3); PbDTW6R(:,3); PbDTW7R(:,3)];
+
+%Mix - Trial 4
+MC = 'E:\Batch\5B\T4Mix\0';
+M1 = 'E:\Batch\5B\T4Mix\1';
+M2 = 'E:\Batch\5B\T4Mix\2';
+M3 = 'E:\Batch\5B\T4Mix\3';
+M4 = 'E:\Batch\5B\T4Mix\4';
+M5 = 'E:\Batch\5B\T4Mix\5';
+M6 = 'E:\Batch\5B\T4Mix\6';
+M7 = 'E:\Batch\5B\T4Mix\7';
+MCS = imageDatastore(MC);
+M1S = imageDatastore(M1);
+M2S = imageDatastore(M2);
+M3S = imageDatastore(M3);
+M4S = imageDatastore(M4);
+M5S = imageDatastore(M5);
+M6S = imageDatastore(M6);
+M7S = imageDatastore(M7);
+M0R = batchR(MCS);
+M1R = batchR(M1S);
+M2R = batchR(M2S);
+M3R = batchR(M3S);
+M4R = batchR(M4S);
+M5R = batchR(M5S);
+M6R = batchR(M6S);
+M7R = batchR(M7S);
+
+MDTW0R = one(MSR,M0R);
+MDTW1R = one(MSR,M1R);
+MDTW2R = one(MSR,M2R);
+MDTW3R = one(MSR,M3R);
+MDTW4R = one(MSR,M4R);
+MDTW5R = one(MSR,M5R);
+MDTW6R = one(MSR,M6R);
+MDTW7R = one(MSR,M7R);
+
+MDTWR = [MDTW0R(:,1); MDTW1R(:,1); MDTW2R(:,1); MDTW3R(:,1); MDTW4R(:,1); MDTW5R(:,1); MDTW6R(:,1); MDTW7R(:,1)];
+MDTWRstd2 = [MDTW0R(:,2); MDTW1R(:,2); MDTW2R(:,2); MDTW3R(:,2); MDTW4R(:,2); MDTW5R(:,2); MDTW6R(:,2); MDTW7R(:,2)];
+MDTWRstd3 = [MDTW0R(:,3); MDTW1R(:,3); MDTW2R(:,3); MDTW3R(:,3); MDTW4R(:,3); MDTW5R(:,3); MDTW6R(:,3); MDTW7R(:,3)];
+
+%Control for comparison
+CC = 'E:\Batch\5B\T5Con\0';
+C1 = 'E:\Batch\5B\T5Con\1';
+C2 = 'E:\Batch\5B\T5Con\2';
+C3 = 'E:\Batch\5B\T5Con\3';
+C4 = 'E:\Batch\5B\T5Con\4';
+C5 = 'E:\Batch\5B\T5Con\5';
+C6 = 'E:\Batch\5B\T5Con\6';
+C7 = 'E:\Batch\5B\T5Con\7';
+CCS = imageDatastore(CC);
+C1S = imageDatastore(C1);
+C2S = imageDatastore(C2);
+C3S = imageDatastore(C3);
+C4S = imageDatastore(C4);
+C5S = imageDatastore(C5);
+C6S = imageDatastore(C6);
+C7S = imageDatastore(C7);
+C0R = batchR(CCS);
+C1R = batchR(C1S);
+C2R = batchR(C2S);
+C3R = batchR(C3S);
+C4R = batchR(C4S);
+C5R = batchR(C5S);
+C6R = batchR(C6S);
+C7R = batchR(C7S);
+
+CDTW0R = one(MSR,C0R);
+CDTW1R = one(MSR,C1R);
+CDTW2R = one(MSR,C2R);
+CDTW3R = one(MSR,C3R);
+CDTW4R = one(MSR,C4R);
+CDTW5R = one(MSR,C5R);
+CDTW6R = one(MSR,C6R);
+CDTW7R = one(MSR,C7R);
+
+CDTWR = [CDTW0R(:,1); CDTW1R(:,1); CDTW2R(:,1); CDTW3R(:,1); CDTW4R(:,1); CDTW5R(:,1); CDTW6R(:,1); CDTW7R(:,1)];
+CDTWRstd2 = [CDTW0R(:,2); CDTW1R(:,2); CDTW2R(:,2); CDTW3R(:,2); CDTW4R(:,2); CDTW5R(:,2); CDTW6R(:,2); CDTW7R(:,2)];
+CDTWRstd3 = [CDTW0R(:,3); CDTW1R(:,3); CDTW2R(:,3); CDTW3R(:,3); CDTW4R(:,3); CDTW5R(:,3); CDTW6R(:,3); CDTW7R(:,3)];
+
+ContM = sum(CDTWR)/8
+Contvar = sum((CDTWR - ContM).^2)./(7);
+Contstd = sqrt(Contvar);
+Contstd2 = ContM + (2.*Contstd')
+Contstd3 = ContM + (3.*Contstd')
+
+%Wet - Trial 6
+WC = 'E:\Batch\5B\T6Wet\0';
+W1 = 'E:\Batch\5B\T6Wet\1';
+W2 = 'E:\Batch\5B\T6Wet\2';
+W3 = 'E:\Batch\5B\T6Wet\3';
+W4 = 'E:\Batch\5B\T6Wet\4';
+W5 = 'E:\Batch\5B\T6Wet\5';
+W6 = 'E:\Batch\5B\T6Wet\6';
+W7 = 'E:\Batch\5B\T6Wet\7';
+WCS = imageDatastore(WC);
+W1S = imageDatastore(W1);
+W2S = imageDatastore(W2);
+W3S = imageDatastore(W3);
+W4S = imageDatastore(W4);
+W5S = imageDatastore(W5);
+W6S = imageDatastore(W6);
+W7S = imageDatastore(W7);
+W0R = batchR(WCS);
+W1R = batchR(W1S);
+W2R = batchR(W2S);
+W3R = batchR(W3S);
+W4R = batchR(W4S);
+W5R = batchR(W5S);
+W6R = batchR(W6S);
+W7R = batchR(W7S);
+
+WDTW0R = one(MSR,W0R);
+WDTW1R = one(MSR,W1R);
+WDTW2R = one(MSR,W2R);
+WDTW3R = one(MSR,W3R);
+WDTW4R = one(MSR,W4R);
+WDTW5R = one(MSR,W5R);
+WDTW6R = one(MSR,W6R);
+WDTW7R = one(MSR,W7R);
+
+WDTWR = [WDTW0R(:,1); WDTW1R(:,1); WDTW2R(:,1); WDTW3R(:,1); WDTW4R(:,1); WDTW5R(:,1); WDTW6R(:,1); WDTW7R(:,1)];
+WDTWRstd2 = [WDTW0R(:,2); WDTW1R(:,2); WDTW2R(:,2); WDTW3R(:,2); WDTW4R(:,2); WDTW5R(:,2); WDTW6R(:,2); WDTW7R(:,2)];
+WDTWRstd3 = [WDTW0R(:,3); WDTW1R(:,3); WDTW2R(:,3); WDTW3R(:,3); WDTW4R(:,3); WDTW5R(:,3); WDTW6R(:,3); WDTW7R(:,3)];
+
+%Dry - Trial 7
+DC = 'E:\Batch\5B\T7Dry\0';
+D1 = 'E:\Batch\5B\T7Dry\1';
+D2 = 'E:\Batch\5B\T7Dry\2';
+D3 = 'E:\Batch\5B\T7Dry\3';
+D4 = 'E:\Batch\5B\T7Dry\4';
+D5 = 'E:\Batch\5B\T7Dry\5';
+D6 = 'E:\Batch\5B\T7Dry\6';
+D7 = 'E:\Batch\5B\T7Dry\7';
+DCS = imageDatastore(DC);
+D1S = imageDatastore(D1);
+D2S = imageDatastore(D2);
+D3S = imageDatastore(D3);
+D4S = imageDatastore(D4);
+D5S = imageDatastore(D5);
+D6S = imageDatastore(D6);
+D7S = imageDatastore(D7);
+D0R = batchR(DCS);
+D1R = batchR(D1S);
+D2R = batchR(D2S);
+D3R = batchR(D3S);
+D4R = batchR(D4S);
+D5R = batchR(D5S);
+D6R = batchR(D6S);
+D7R = batchR(D7S);
+
+DDTW0R = one(MSR,D0R);
+DDTW1R = one(MSR,D1R);
+DDTW2R = one(MSR,D2R);
+DDTW3R = one(MSR,D3R);
+DDTW4R = one(MSR,D4R);
+DDTW5R = one(MSR,D5R);
+DDTW6R = one(MSR,D6R);
+DDTW7R = one(MSR,D7R);
+
+DDTWR = [DDTW0R(:,1); DDTW1R(:,1); DDTW2R(:,1); DDTW3R(:,1); DDTW4R(:,1); DDTW5R(:,1); DDTW6R(:,1); DDTW7R(:,1)];
+DDTWRstd2 = [DDTW0R(:,2); DDTW1R(:,2); DDTW2R(:,2); DDTW3R(:,2); DDTW4R(:,2); DDTW5R(:,2); DDTW6R(:,2); DDTW7R(:,2)];
+DDTWRstd3 = [DDTW0R(:,3); DDTW1R(:,3); DDTW2R(:,3); DDTW3R(:,3); DDTW4R(:,3); DDTW5R(:,3); DDTW6R(:,3); DDTW7R(:,3)];
+
+%Nutrients - Trial 8
+NC = 'E:\Batch\5B\T8Nut\0';
+N1 = 'E:\Batch\5B\T8Nut\1';
+N2 = 'E:\Batch\5B\T8Nut\2';
+N3 = 'E:\Batch\5B\T8Nut\3';
+N4 = 'E:\Batch\5B\T8Nut\4';
+N5 = 'E:\Batch\5B\T8Nut\5';
+N6 = 'E:\Batch\5B\T8Nut\6';
+N7 = 'E:\Batch\5B\T8Nut\7';
+NCS = imageDatastore(NC);
+N1S = imageDatastore(N1);
+N2S = imageDatastore(N2);
+N3S = imageDatastore(N3);
+N4S = imageDatastore(N4);
+N5S = imageDatastore(N5);
+N6S = imageDatastore(N6);
+N7S = imageDatastore(N7);
+N0R = batchR(NCS);
+N1R = batchR(N1S);
+N2R = batchR(N2S);
+N3R = batchR(N3S);
+N4R = batchR(N4S);
+N5R = batchR(N5S);
+N6R = batchR(N6S);
+N7R = batchR(N7S);
+
+NDTW0R = one(MSR,N0R);
+NDTW1R = one(MSR,N1R);
+NDTW2R = one(MSR,N2R);
+NDTW3R = one(MSR,N3R);
+NDTW4R = one(MSR,N4R);
+NDTW5R = one(MSR,N5R);
+NDTW6R = one(MSR,N6R);
+NDTW7R = one(MSR,N7R);
+
+NDTWR = [NDTW0R(:,1); NDTW1R(:,1); NDTW2R(:,1); NDTW3R(:,1); NDTW4R(:,1); NDTW5R(:,1); NDTW6R(:,1); NDTW7R(:,1)];
+NDTWRstd2 = [NDTW0R(:,2); NDTW1R(:,2); NDTW2R(:,2); NDTW3R(:,2); NDTW4R(:,2); NDTW5R(:,2); NDTW6R(:,2); NDTW7R(:,2)];
+NDTWRstd3 = [NDTW0R(:,3); NDTW1R(:,3); NDTW2R(:,3); NDTW3R(:,3); NDTW4R(:,3); NDTW5R(:,3); NDTW6R(:,3); NDTW7R(:,3)];
+
+%Long - Trial 9
+LC = 'E:\Batch\5B\T9Long\0';
+L1 = 'E:\Batch\5B\T9Long\1';
+L2 = 'E:\Batch\5B\T9Long\2';
+L3 = 'E:\Batch\5B\T9Long\3';
+L4 = 'E:\Batch\5B\T9Long\4';
+L5 = 'E:\Batch\5B\T9Long\5';
+L6 = 'E:\Batch\5B\T9Long\6';
+L7 = 'E:\Batch\5B\T9Long\7';
+LCS = imageDatastore(LC);
+L1S = imageDatastore(L1);
+L2S = imageDatastore(L2);
+L3S = imageDatastore(L3);
+L4S = imageDatastore(L4);
+L5S = imageDatastore(L5);
+L6S = imageDatastore(L6);
+L7S = imageDatastore(L7);
+L0R = batchR(LCS);
+L1R = batchR(L1S);
+L2R = batchR(L2S);
+L3R = batchR(L3S);
+L4R = batchR(L4S);
+L5R = batchR(L5S);
+L6R = batchR(L6S);
+L7R = batchR(L7S);
+
+LDTW0R = one(MSR,L0R);
+LDTW1R = one(MSR,L1R);
+LDTW2R = one(MSR,L2R);
+LDTW3R = one(MSR,L3R);
+LDTW4R = one(MSR,L4R);
+LDTW5R = one(MSR,L5R);
+LDTW6R = one(MSR,L6R);
+LDTW7R = one(MSR,L7R);
+
+LDTWR = [LDTW0R(:,1); LDTW1R(:,1); LDTW2R(:,1); LDTW3R(:,1); LDTW4R(:,1); LDTW5R(:,1); LDTW6R(:,1); LDTW7R(:,1)];
+LDTWRstd2 = [LDTW0R(:,2); LDTW1R(:,2); LDTW2R(:,2); LDTW3R(:,2); LDTW4R(:,2); LDTW5R(:,2); LDTW6R(:,2); LDTW7R(:,2)];
+LDTWRstd3 = [LDTW0R(:,3); LDTW1R(:,3); LDTW2R(:,3); LDTW3R(:,3); LDTW4R(:,3); LDTW5R(:,3); LDTW6R(:,3); LDTW7R(:,3)];
+
+%Short - Trial 10
+SC = 'E:\Batch\5B\T10Shrt\0';
+S1 = 'E:\Batch\5B\T10Shrt\1';
+S2 = 'E:\Batch\5B\T10Shrt\2';
+S3 = 'E:\Batch\5B\T10Shrt\3';
+S4 = 'E:\Batch\5B\T10Shrt\4';
+S5 = 'E:\Batch\5B\T10Shrt\5';
+S6 = 'E:\Batch\5B\T10Shrt\6';
+S7 = 'E:\Batch\5B\T10Shrt\7';
+SCS = imageDatastore(SC);
+S1S = imageDatastore(S1);
+S2S = imageDatastore(S2);
+S3S = imageDatastore(S3);
+S4S = imageDatastore(S4);
+S5S = imageDatastore(S5);
+S6S = imageDatastore(S6);
+S7S = imageDatastore(S7);
+S0R = batchR(SCS);
+S1R = batchR(S1S);
+S2R = batchR(S2S);
+S3R = batchR(S3S);
+S4R = batchR(S4S);
+S5R = batchR(S5S);
+S6R = batchR(S6S);
+S7R = batchR(S7S);
+
+SDTW0R = one(MSR,S0R);
+SDTW1R = one(MSR,S1R);
+SDTW2R = one(MSR,S2R);
+SDTW3R = one(MSR,S3R);
+SDTW4R = one(MSR,S4R);
+SDTW5R = one(MSR,S5R);
+SDTW6R = one(MSR,S6R);
+SDTW7R = one(MSR,S7R);
+
+SDTWR = [SDTW0R(:,1); SDTW1R(:,1); SDTW2R(:,1); SDTW3R(:,1); SDTW4R(:,1); SDTW5R(:,1); SDTW6R(:,1); SDTW7R(:,1)];
+SDTWRstd2 = [SDTW0R(:,2); SDTW1R(:,2); SDTW2R(:,2); SDTW3R(:,2); SDTW4R(:,2); SDTW5R(:,2); SDTW6R(:,2); SDTW7R(:,2)];
+SDTWRstd3 = [SDTW0R(:,3); SDTW1R(:,3); SDTW2R(:,3); SDTW3R(:,3); SDTW4R(:,3); SDTW5R(:,3); SDTW6R(:,3); SDTW7R(:,3)];
+
+%Dark - Trial 11
+AC = 'E:\Batch\5B\T11Dark\0';
+A1 = 'E:\Batch\5B\T11Dark\1';
+A2 = 'E:\Batch\5B\T11Dark\2';
+A3 = 'E:\Batch\5B\T11Dark\3';
+A4 = 'E:\Batch\5B\T11Dark\4';
+A5 = 'E:\Batch\5B\T11Dark\5';
+A6 = 'E:\Batch\5B\T11Dark\6';
+A7 = 'E:\Batch\5B\T11Dark\7';
+ACS = imageDatastore(AC);
+A1S = imageDatastore(A1);
+A2S = imageDatastore(A2);
+A3S = imageDatastore(A3);
+A4S = imageDatastore(A4);
+A5S = imageDatastore(A5);
+A6S = imageDatastore(A6);
+A7S = imageDatastore(A7);
+A0R = batchR(ACS);
+A1R = batchR(A1S);
+A2R = batchR(A2S);
+A3R = batchR(A3S);
+A4R = batchR(A4S);
+A5R = batchR(A5S);
+A6R = batchR(A6S);
+A7R = batchR(A7S);
+
+ADTW0R = one(MSR,A0R);
+ADTW1R = one(MSR,A1R);
+ADTW2R = one(MSR,A2R);
+ADTW3R = one(MSR,A3R);
+ADTW4R = one(MSR,A4R);
+ADTW5R = one(MSR,A5R);
+ADTW6R = one(MSR,A6R);
+ADTW7R = one(MSR,A7R);
+
+ADTWR = [ADTW0R(:,1); ADTW1R(:,1); ADTW2R(:,1); ADTW3R(:,1); ADTW4R(:,1); ADTW5R(:,1); ADTW6R(:,1); ADTW7R(:,1)];
+ADTWRstd2 = [ADTW0R(:,2); ADTW1R(:,2); ADTW2R(:,2); ADTW3R(:,2); ADTW4R(:,2); ADTW5R(:,2); ADTW6R(:,2); ADTW7R(:,2)];
+ADTWRstd3 = [ADTW0R(:,3); ADTW1R(:,3); ADTW2R(:,3); ADTW3R(:,3); ADTW4R(:,3); ADTW5R(:,3); ADTW6R(:,3); ADTW7R(:,3)];
+
+x = (0:7);
+figure;
+plot(x,CuDTWR,'LineWidth',2);
+hold on
+plot(x,ZnDTWR,'LineWidth',2);
+plot(x,PbDTWR,'LineWidth',2);
+plot(x,MDTWR,'LineWidth',2);
+%plot(x,crmean);
+%yline(Mmean,'k');
+%yline(Mstd2pos,'k--');
+%yline(Mstd3pos,'k:');
+yline(ContM,'k','LineWidth',2);
+yline(Contstd2,'k--','LineWidth',2);
+yline(Contstd3,'k:','LineWidth',2);
+%legend('Cu','Zn','Pb','Mix','Mean','2\sigma','3\sigma');
+set(gca,'fontname','arial','fontsize',18,'fontweight','bold');
+xlabel('Time(days)')
+%ylabel('DTW')
+axis([0 7 .05 .3]);
+hold off
+
+%ALL figure thing
+figure;
+plot(x,CuDTWR);
+hold on
+plot(x,ZnDTWR);
+plot(x,PbDTWR);
+plot(x,MDTWR);
+plot(x,CDTWR);
+plot(x,WDTWR);
+plot(x,DDTWR);
+plot(x,NDTWR);
+plot(x,LDTWR);
+plot(x,SDTWR);
+plot(x,ADTWR);
+legend('Cu','Zn','Pb','Mix','Cont','Wet','Dry','Nutr','Long','Short','Dark');
+yline(Mmean,'k');
+yline(Mstd2pos,'k--');
+yline(Mstd3pos,'k:');
+yline(Mstd2neg,'k--');
+yline(Mstd3neg,'k:');
+hold off
+
+
+%GREEN
+MCG = batchMG(MasterCS);
+MSG = batchG(MasterCS);
+
+%COPPER TRIAL 1
+Cu0G = batchG(CuCS);
+Cu1G = batchG(Cu1S);
+Cu2G = batchG(Cu2S);
+Cu3G = batchG(Cu3S);
+Cu4G = batchG(Cu4S);
+Cu5G = batchG(Cu5S);
+Cu6G = batchG(Cu6S);
+Cu7G = batchG(Cu7S);
+
+CuDTW0G = one(MSG,Cu0G);
+CuDTW1G = one(MSG,Cu1G);
+CuDTW2G = one(MSG,Cu2G);
+CuDTW3G = one(MSG,Cu3G);
+CuDTW4G = one(MSG,Cu4G);
+CuDTW5G = one(MSG,Cu5G);
+CuDTW6G = one(MSG,Cu6G);
+CuDTW7G = one(MSG,Cu7G);
+
+CuDTWG = [CuDTW0G(:,1); CuDTW1G(:,1); CuDTW2G(:,1); CuDTW3G(:,1); CuDTW4G(:,1); CuDTW5G(:,1); CuDTW6G(:,1); CuDTW7G(:,1)];
+
+%zinc trial 2
+Zn0G = batchG(ZnCS);
+Zn1G = batchG(Zn1S);
+Zn2G = batchG(Zn2S);
+Zn3G = batchG(Zn3S);
+Zn4G = batchG(Zn4S);
+Zn5G = batchG(Zn5S);
+Zn6G = batchG(Zn6S);
+Zn7G = batchG(Zn7S);
+
+ZnDTW0G = one(MSG,Zn0G);
+ZnDTW1G = one(MSG,Zn1G);
+ZnDTW2G = one(MSG,Zn2G);
+ZnDTW3G = one(MSG,Zn3G);
+ZnDTW4G = one(MSG,Zn4G);
+ZnDTW5G = one(MSG,Zn5G);
+ZnDTW6G = one(MSG,Zn6G);
+ZnDTW7G = one(MSG,Zn7G);
+
+ZnDTWG = [ZnDTW0G(:,1); ZnDTW1G(:,1); ZnDTW2G(:,1); ZnDTW3G(:,1); ZnDTW4G(:,1); ZnDTW5G(:,1); ZnDTW6G(:,1); ZnDTW7G(:,1)];
+
+%lead trial 3
+Pb0G = batchG(PbCS);
+Pb1G = batchG(Pb1S);
+Pb2G = batchG(Pb2S);
+Pb3G = batchG(Pb3S);
+Pb4G = batchG(Pb4S);
+Pb5G = batchG(Pb5S);
+Pb6G = batchG(Pb6S);
+Pb7G = batchG(Pb7S);
+
+PbDTW0G = one(MSG,Pb0G);
+PbDTW1G = one(MSG,Pb1G);
+PbDTW2G = one(MSG,Pb2G);
+PbDTW3G = one(MSG,Pb3G);
+PbDTW4G = one(MSG,Pb4G);
+PbDTW5G = one(MSG,Pb5G);
+PbDTW6G = one(MSG,Pb6G);
+PbDTW7G = one(MSG,Pb7G);
+
+PbDTWG = [PbDTW0G(:,1); PbDTW1G(:,1); PbDTW2G(:,1); PbDTW3G(:,1); PbDTW4G(:,1); PbDTW5G(:,1); PbDTW6G(:,1); PbDTW7G(:,1)];
+
+%Mix - Trial 4
+M0G = batchG(MCS);
+M1G = batchG(M1S);
+M2G = batchG(M2S);
+M3G = batchG(M3S);
+M4G = batchG(M4S);
+M5G = batchG(M5S);
+M6G = batchG(M6S);
+M7G = batchG(M7S);
+
+MDTW0G = one(MSG,M0G);
+MDTW1G = one(MSG,M1G);
+MDTW2G = one(MSG,M2G);
+MDTW3G = one(MSG,M3G);
+MDTW4G = one(MSG,M4G);
+MDTW5G = one(MSG,M5G);
+MDTW6G = one(MSG,M6G);
+MDTW7G = one(MSG,M7G);
+
+MDTWG = [MDTW0G(:,1); MDTW1G(:,1); MDTW2G(:,1); MDTW3G(:,1); MDTW4G(:,1); MDTW5G(:,1); MDTW6G(:,1); MDTW7G(:,1)];
+
+%Control for comparison
+C0G = batchG(CCS);
+C1G = batchG(C1S);
+C2G = batchG(C2S);
+C3G = batchG(C3S);
+C4G = batchG(C4S);
+C5G = batchG(C5S);
+C6G = batchG(C6S);
+C7G = batchG(C7S);
+
+CDTW0G = one(MSG,C0G);
+CDTW1G = one(MSG,C1G);
+CDTW2G = one(MSG,C2G);
+CDTW3G = one(MSG,C3G);
+CDTW4G = one(MSG,C4G);
+CDTW5G = one(MSG,C5G);
+CDTW6G = one(MSG,C6G);
+CDTW7G = one(MSG,C7G);
+
+CDTWG = [CDTW0G(:,1); CDTW1G(:,1); CDTW2G(:,1); CDTW3G(:,1); CDTW4G(:,1); CDTW5G(:,1); CDTW6G(:,1); CDTW7G(:,1)];
+
+ContMg = sum(CDTWG)/8
+Contvarg = sum((CDTWG - ContMg).^2)./(7);
+Contstdg = sqrt(Contvarg);
+Contstd2g = ContMg + (2.*Contstdg')
+Contstd3g = ContMg + (3.*Contstdg')
+
+%Wet - Trial 6
+W0G = batchG(WCS);
+W1G = batchG(W1S);
+W2G = batchG(W2S);
+W3G = batchG(W3S);
+W4G = batchG(W4S);
+W5G = batchG(W5S);
+W6G = batchG(W6S);
+W7G = batchG(W7S);
+
+WDTW0G = one(MSG,W0G);
+WDTW1G = one(MSG,W1G);
+WDTW2G = one(MSG,W2G);
+WDTW3G = one(MSG,W3G);
+WDTW4G = one(MSG,W4G);
+WDTW5G = one(MSG,W5G);
+WDTW6G = one(MSG,W6G);
+WDTW7G = one(MSG,W7G);
+
+WDTWG = [WDTW0G(:,1); WDTW1G(:,1); WDTW2G(:,1); WDTW3G(:,1); WDTW4G(:,1); WDTW5G(:,1); WDTW6G(:,1); WDTW7G(:,1)];
+
+%Dry - Trial 7
+D0G = batchG(DCS);
+D1G = batchG(D1S);
+D2G = batchG(D2S);
+D3G = batchG(D3S);
+D4G = batchG(D4S);
+D5G = batchG(D5S);
+D6G = batchG(D6S);
+D7G = batchG(D7S);
+
+DDTW0G = one(MSG,D0G);
+DDTW1G = one(MSG,D1G);
+DDTW2G = one(MSG,D2G);
+DDTW3G = one(MSG,D3G);
+DDTW4G = one(MSG,D4G);
+DDTW5G = one(MSG,D5G);
+DDTW6G = one(MSG,D6G);
+DDTW7G = one(MSG,D7G);
+
+DDTWG = [DDTW0G(:,1); DDTW1G(:,1); DDTW2G(:,1); DDTW3G(:,1); DDTW4G(:,1); DDTW5G(:,1); DDTW6G(:,1); DDTW7G(:,1)];
+
+%Nutrients - Trial 8
+N0G = batchG(NCS);
+N1G = batchG(N1S);
+N2G = batchG(N2S);
+N3G = batchG(N3S);
+N4G = batchG(N4S);
+N5G = batchG(N5S);
+N6G = batchG(N6S);
+N7G = batchG(N7S);
+
+NDTW0G = one(MSG,N0G);
+NDTW1G = one(MSG,N1G);
+NDTW2G = one(MSG,N2G);
+NDTW3G = one(MSG,N3G);
+NDTW4G = one(MSG,N4G);
+NDTW5G = one(MSG,N5G);
+NDTW6G = one(MSG,N6G);
+NDTW7G = one(MSG,N7G);
+
+NDTWG = [NDTW0G(:,1); NDTW1G(:,1); NDTW2G(:,1); NDTW3G(:,1); NDTW4G(:,1); NDTW5G(:,1); NDTW6G(:,1); NDTW7G(:,1)];
+
+%Long - Trial 9
+L0G = batchG(LCS);
+L1G = batchG(L1S);
+L2G = batchG(L2S);
+L3G = batchG(L3S);
+L4G = batchG(L4S);
+L5G = batchG(L5S);
+L6G = batchG(L6S);
+L7G = batchG(L7S);
+
+LDTW0G = one(MCG,L0G);
+LDTW1G = one(MCG,L1G);
+LDTW2G = one(MCG,L2G);
+LDTW3G = one(MCG,L3G);
+LDTW4G = one(MCG,L4G);
+LDTW5G = one(MCG,L5G);
+LDTW6G = one(MCG,L6G);
+LDTW7G = one(MCG,L7G);
+
+LDTWG = [LDTW0G(:,1); LDTW1G(:,1); LDTW2G(:,1); LDTW3G(:,1); LDTW4G(:,1); LDTW5G(:,1); LDTW6G(:,1); LDTW7G(:,1)];
+
+%Short - Trial 10
+S0G = batchG(SCS);
+S1G = batchG(S1S);
+S2G = batchG(S2S);
+S3G = batchG(S3S);
+S4G = batchG(S4S);
+S5G = batchG(S5S);
+S6G = batchG(S6S);
+S7G = batchG(S7S);
+
+SDTW0G = one(MSG,S0G);
+SDTW1G = one(MSG,S1G);
+SDTW2G = one(MSG,S2G);
+SDTW3G = one(MSG,S3G);
+SDTW4G = one(MSG,S4G);
+SDTW5G = one(MSG,S5G);
+SDTW6G = one(MSG,S6G);
+SDTW7G = one(MSG,S7G);
+
+SDTWG = [SDTW0G(:,1); SDTW1G(:,1); SDTW2G(:,1); SDTW3G(:,1); SDTW4G(:,1); SDTW5G(:,1); SDTW6G(:,1); SDTW7G(:,1)];
+
+%Dark - Trial 11
+A0G = batchG(ACS);
+A1G = batchG(A1S);
+A2G = batchG(A2S);
+A3G = batchG(A3S);
+A4G = batchG(A4S);
+A5G = batchG(A5S);
+A6G = batchG(A6S);
+A7G = batchG(A7S);
+
+ADTW0G = one(MSG,A0G);
+ADTW1G = one(MSG,A1G);
+ADTW2G = one(MSG,A2G);
+ADTW3G = one(MSG,A3G);
+ADTW4G = one(MSG,A4G);
+ADTW5G = one(MSG,A5G);
+ADTW6G = one(MSG,A6G);
+ADTW7G = one(MSG,A7G);
+
+ADTWG = [ADTW0G(:,1); ADTW1G(:,1); ADTW2G(:,1); ADTW3G(:,1); ADTW4G(:,1); ADTW5G(:,1); ADTW6G(:,1); ADTW7G(:,1)];
+
+x = (0:7);
+figure;
+plot(x,CuDTWG,'LineWidth',2);
+hold on
+plot(x,ZnDTWG,'LineWidth',2);
+plot(x,PbDTWG,'LineWidth',2);
+plot(x,MDTWG,'LineWidth',2);
+%plot(x,crmean);
+%yline(Mmean,'k');
+%yline(Mstd2pos,'k--');
+%yline(Mstd3pos,'k:');
+yline(ContMg,'k','LineWidth',2);
+yline(Contstd2g,'k--','LineWidth',2);
+yline(Contstd3g,'k:','LineWidth',2);
+%legend('Cu','Zn','Pb','Mix','Mean','2\sigma','3\sigma');
+set(gca,'fontname','arial','fontsize',18,'fontweight','bold');
+xlabel('Time(days)')
+%ylabel('DTW')
+axis([0 7 .05 .3]);
+hold off
+
+
+%BLUE
+MCB = batchMB(MasterCS);
+MSB = batchB(MasterCS);
+
+%COPPER TRIAL 1
+Cu0B = batchB(CuCS);
+Cu1B = batchB(Cu1S);
+Cu2B = batchB(Cu2S);
+Cu3B = batchB(Cu3S);
+Cu4B = batchB(Cu4S);
+Cu5B = batchB(Cu5S);
+Cu6B = batchB(Cu6S);
+Cu7B = batchB(Cu7S);
+
+CuDTW0B = one(MSB,Cu0B);
+CuDTW1B = one(MSB,Cu1B);
+CuDTW2B = one(MSB,Cu2B);
+CuDTW3B = one(MSB,Cu3B);
+CuDTW4B = one(MSB,Cu4B);
+CuDTW5B = one(MSB,Cu5B);
+CuDTW6B = one(MSB,Cu6B);
+CuDTW7B = one(MSB,Cu7B);
+
+CuDTWB = [CuDTW0B(:,1); CuDTW1B(:,1); CuDTW2B(:,1); CuDTW3B(:,1); CuDTW4B(:,1); CuDTW5B(:,1); CuDTW6B(:,1); CuDTW7B(:,1)];
+%CuDTWB4 = [CuDTW0B(:,4); CuDTW1B(:,4); CuDTW2B(:,4); CuDTW3B(:,4); CuDTW4B(:,4); CuDTW5B(:,4); CuDTW6B(:,4); CuDTW7B(:,4)];
+
+%zinc trial 2
+Zn0B = batchB(ZnCS);
+Zn1B = batchB(Zn1S);
+Zn2B = batchB(Zn2S);
+Zn3B = batchB(Zn3S);
+Zn4B = batchB(Zn4S);
+Zn5B = batchB(Zn5S);
+Zn6B = batchB(Zn6S);
+Zn7B = batchB(Zn7S);
+
+ZnDTW0B = one(MSB,Zn0B);
+ZnDTW1B = one(MSB,Zn1B);
+ZnDTW2B = one(MSB,Zn2B);
+ZnDTW3B = one(MSB,Zn3B);
+ZnDTW4B = one(MSB,Zn4B);
+ZnDTW5B = one(MSB,Zn5B);
+ZnDTW6B = one(MSB,Zn6B);
+ZnDTW7B = one(MSB,Zn7B);
+
+ZnDTWB = [ZnDTW0B(:,1); ZnDTW1B(:,1); ZnDTW2B(:,1); ZnDTW3B(:,1); ZnDTW4B(:,1); ZnDTW5B(:,1); ZnDTW6B(:,1); ZnDTW7B(:,1)];
+%ZnDTWB4 = [ZnDTW0B(:,4); ZnDTW1B(:,4); ZnDTW2B(:,4); ZnDTW3B(:,4); ZnDTW4B(:,4); ZnDTW5B(:,4); ZnDTW6B(:,4); ZnDTW7B(:,4)];
+
+%lead trial 3
+Pb0B = batchB(PbCS);
+Pb1B = batchB(Pb1S);
+Pb2B = batchB(Pb2S);
+Pb3B = batchB(Pb3S);
+Pb4B = batchB(Pb4S);
+Pb5B = batchB(Pb5S);
+Pb6B = batchB(Pb6S);
+Pb7B = batchB(Pb7S);
+
+PbDTW0B = one(MSB,Pb0B);
+PbDTW1B = one(MSB,Pb1B);
+PbDTW2B = one(MSB,Pb2B);
+PbDTW3B = one(MSB,Pb3B);
+PbDTW4B = one(MSB,Pb4B);
+PbDTW5B = one(MSB,Pb5B);
+PbDTW6B = one(MSB,Pb6B);
+PbDTW7B = one(MSB,Pb7B);
+
+PbDTWB = [PbDTW0B(:,1); PbDTW1B(:,1); PbDTW2B(:,1); PbDTW3B(:,1); PbDTW4B(:,1); PbDTW5B(:,1); PbDTW6B(:,1); PbDTW7B(:,1)];
+%PbDTWB4 = [PbDTW0B(:,4); PbDTW1B(:,4); PbDTW2B(:,4); PbDTW3B(:,4); PbDTW4B(:,4); PbDTW5B(:,4); PbDTW6B(:,4); PbDTW7B(:,4)];
+
+%Mix - Trial 4
+M0B = batchB(MCS);
+M1B = batchB(M1S);
+M2B = batchB(M2S);
+M3B = batchB(M3S);
+M4B = batchB(M4S);
+M5B = batchB(M5S);
+M6B = batchB(M6S);
+M7B = batchB(M7S);
+
+MDTW0B = one(MSB,M0B);
+MDTW1B = one(MSB,M1B);
+MDTW2B = one(MSB,M2B);
+MDTW3B = one(MSB,M3B);
+MDTW4B = one(MSB,M4B);
+MDTW5B = one(MSB,M5B);
+MDTW6B = one(MSB,M6B);
+MDTW7B = one(MSB,M7B);
+
+MDTWB = [MDTW0B(:,1); MDTW1B(:,1); MDTW2B(:,1); MDTW3B(:,1); MDTW4B(:,1); MDTW5B(:,1); MDTW6B(:,1); MDTW7B(:,1)];
+%MDTWB4 = [MDTW0B(:,4); MDTW1B(:,4); MDTW2B(:,4); MDTW3B(:,4); MDTW4B(:,4); MDTW5B(:,4); MDTW6B(:,4); MDTW7B(:,4)];
+
+%Control for comparison
+C0B = batchB(CCS);
+C1B = batchB(C1S);
+C2B = batchB(C2S);
+C3B = batchB(C3S);
+C4B = batchB(C4S);
+C5B = batchB(C5S);
+C6B = batchB(C6S);
+C7B = batchB(C7S);
+
+CDTW0B = one(MSB,C0B);
+CDTW1B = one(MSB,C1B);
+CDTW2B = one(MSB,C2B);
+CDTW3B = one(MSB,C3B);
+CDTW4B = one(MSB,C4B);
+CDTW5B = one(MSB,C5B);
+CDTW6B = one(MSB,C6B);
+CDTW7B = one(MSB,C7B);
+
+CDTWB = [CDTW0B(:,1); CDTW1B(:,1); CDTW2B(:,1); CDTW3B(:,1); CDTW4B(:,1); CDTW5B(:,1); CDTW6B(:,1); CDTW7B(:,1)];
+
+ContMb = sum(CDTWB)/8
+Contvarb = sum((CDTWB - ContMb).^2)./(7);
+Contstdb = sqrt(Contvarb);
+Contstd2b = ContMb + (2.*Contstdb')
+Contstd3b = ContMb + (3.*Contstdb')
+
+%Wet - Trial 6
+W0B = batchB(WCS);
+W1B = batchB(W1S);
+W2B = batchB(W2S);
+W3B = batchB(W3S);
+W4B = batchB(W4S);
+W5B = batchB(W5S);
+W6B = batchB(W6S);
+W7B = batchB(W7S);
+
+WDTW0B = one(MSB,W0B);
+WDTW1B = one(MSB,W1B);
+WDTW2B = one(MSB,W2B);
+WDTW3B = one(MSB,W3B);
+WDTW4B = one(MSB,W4B);
+WDTW5B = one(MSB,W5B);
+WDTW6B = one(MSB,W6B);
+WDTW7B = one(MSB,W7B);
+
+WDTWB = [WDTW0B(:,1); WDTW1B(:,1); WDTW2B(:,1); WDTW3B(:,1); WDTW4B(:,1); WDTW5B(:,1); WDTW6B(:,1); WDTW7B(:,1)];
+
+%Dry - Trial 7
+D0B = batchB(DCS);
+D1B = batchB(D1S);
+D2B = batchB(D2S);
+D3B = batchB(D3S);
+D4B = batchB(D4S);
+D5B = batchB(D5S);
+D6B = batchB(D6S);
+D7B = batchB(D7S);
+
+DDTW0B = one(MSB,D0B);
+DDTW1B = one(MSB,D1B);
+DDTW2B = one(MSB,D2B);
+DDTW3B = one(MSB,D3B);
+DDTW4B = one(MSB,D4B);
+DDTW5B = one(MSB,D5B);
+DDTW6B = one(MSB,D6B);
+DDTW7B = one(MSB,D7B);
+
+DDTWB = [DDTW0B(:,1); DDTW1B(:,1); DDTW2B(:,1); DDTW3B(:,1); DDTW4B(:,1); DDTW5B(:,1); DDTW6B(:,1); DDTW7B(:,1)];
+
+%Nutrients - Trial 8
+N0B = batchB(NCS);
+N1B = batchB(N1S);
+N2B = batchB(N2S);
+N3B = batchB(N3S);
+N4B = batchB(N4S);
+N5B = batchB(N5S);
+N6B = batchB(N6S);
+N7B = batchB(N7S);
+
+NDTW0B = one(MSB,N0B);
+NDTW1B = one(MSB,N1B);
+NDTW2B = one(MSB,N2B);
+NDTW3B = one(MSB,N3B);
+NDTW4B = one(MSB,N4B);
+NDTW5B = one(MSB,N5B);
+NDTW6B = one(MSB,N6B);
+NDTW7B = one(MSB,N7B);
+
+NDTWB = [NDTW0B(:,1); NDTW1B(:,1); NDTW2B(:,1); NDTW3B(:,1); NDTW4B(:,1); NDTW5B(:,1); NDTW6B(:,1); NDTW7B(:,1)];
+
+%Long - Trial 9
+L0B = batchB(LCS);
+L1B = batchB(L1S);
+L2B = batchB(L2S);
+L3B = batchB(L3S);
+L4B = batchB(L4S);
+L5B = batchB(L5S);
+L6B = batchB(L6S);
+L7B = batchB(L7S);
+
+LDTW0B = one(MSB,L0B);
+LDTW1B = one(MSB,L1B);
+LDTW2B = one(MSB,L2B);
+LDTW3B = one(MSB,L3B);
+LDTW4B = one(MSB,L4B);
+LDTW5B = one(MSB,L5B);
+LDTW6B = one(MSB,L6B);
+LDTW7B = one(MSB,L7B);
+
+LDTWB = [LDTW0B(:,1); LDTW1B(:,1); LDTW2B(:,1); LDTW3B(:,1); LDTW4B(:,1); LDTW5B(:,1); LDTW6B(:,1); LDTW7B(:,1)];
+
+%Short - Trial 10
+S0B = batchB(SCS);
+S1B = batchB(S1S);
+S2B = batchB(S2S);
+S3B = batchB(S3S);
+S4B = batchB(S4S);
+S5B = batchB(S5S);
+S6B = batchB(S6S);
+S7B = batchB(S7S);
+
+SDTW0B = one(MSB,S0B);
+SDTW1B = one(MSB,S1B);
+SDTW2B = one(MSB,S2B);
+SDTW3B = one(MSB,S3B);
+SDTW4B = one(MSB,S4B);
+SDTW5B = one(MSB,S5B);
+SDTW6B = one(MSB,S6B);
+SDTW7B = one(MSB,S7B);
+
+SDTWB = [SDTW0B(:,1); SDTW1B(:,1); SDTW2B(:,1); SDTW3B(:,1); SDTW4B(:,1); SDTW5B(:,1); SDTW6B(:,1); SDTW7B(:,1)];
+
+%Dark - Trial 11
+A0B = batchB(ACS);
+A1B = batchB(A1S);
+A2B = batchB(A2S);
+A3B = batchB(A3S);
+A4B = batchB(A4S);
+A5B = batchB(A5S);
+A6B = batchB(A6S);
+A7B = batchB(A7S);
+
+ADTW0B = one(MSB,A0B);
+ADTW1B = one(MSB,A1B);
+ADTW2B = one(MSB,A2B);
+ADTW3B = one(MSB,A3B);
+ADTW4B = one(MSB,A4B);
+ADTW5B = one(MSB,A5B);
+ADTW6B = one(MSB,A6B);
+ADTW7B = one(MSB,A7B);
+
+ADTWB = [ADTW0B(:,1); ADTW1B(:,1); ADTW2B(:,1); ADTW3B(:,1); ADTW4B(:,1); ADTW5B(:,1); ADTW6B(:,1); ADTW7B(:,1)];
+
+x = (0:7);
+figure;
+plot(x,CuDTWB,'LineWidth',2);
+hold on
+plot(x,ZnDTWB,'LineWidth',2);
+plot(x,PbDTWB,'LineWidth',2);
+plot(x,MDTWB,'LineWidth',2);
+%plot(x,crmean);
+%yline(Mmean,'k');
+%yline(Mstd2pos,'k--');
+%yline(Mstd3pos,'k:');
+yline(ContMb,'k','LineWidth',2);
+yline(Contstd2b,'k--','LineWidth',2);
+yline(Contstd3b,'k:','LineWidth',2);
+%legend('Cu','Zn','Pb','Mix','Mean','2\sigma','3\sigma');
+set(gca,'fontname','arial','fontsize',18,'fontweight','bold');
+xlabel('Time(days)');
+%ylabel('DTW');
+axis([0 7 .05 .3]);
+hold off;
+
+%err
+x = (0:7);
+figure;
+errorbar(x,CuDTWB,CuDTWB4,'LineWidth',2);
+hold on
+errorbar(x,ZnDTWB,ZnDTWB4,'LineWidth',2);
+errorbar(x,PbDTWB,PbDTWB4,'LineWidth',2);
+errorbar(x,MDTWB,MDTWB4,'LineWidth',2);
+%plot(x,crmean);
+%yline(Mmean,'k');
+%yline(Mstd2pos,'k--');
+%yline(Mstd3pos,'k:');
+yline(ContMb,'k','LineWidth',2);
+yline(Contstd2b,'k--','LineWidth',2);
+yline(Contstd3b,'k:','LineWidth',2);
+legend('Cu','Zn','Pb','Mix','Mean','2\sigma','3\sigma');
+set(gca,'fontname','arial','fontsize',18,'fontweight','bold');
+xlabel('Time(days)')
+ylabel('DTW')
+
+
+%environmental
+x = (0:7);
+figure;
+plot(x,WDTWB,'LineWidth',2);
+hold on
+plot(x,DDTWB,'LineWidth',2);
+plot(x,NDTWB,'LineWidth',2);
+plot(x,LDTWB,'LineWidth',2);
+plot(x,SDTWB,'LineWidth',2);
+plot(x,ADTWB,'LineWidth',2);
+%plot(x,crmean);
+%yline(Mmean,'k');
+%yline(Mstd2pos,'k--');
+%yline(Mstd3pos,'k:');
+yline(ContMb,'k','LineWidth',2);
+yline(Contstd2b,'k--','LineWidth',2);
+yline(Contstd3b,'k:','LineWidth',2);
+legend('Cu','Zn','Pb','Mix','Mean','2\sigma','3\sigma');
+set(gca,'fontname','arial','fontsize',18,'fontweight','bold');
+xlabel('Time(days)')
+ylabel('DTW')
+
+
+%ratios
+%ratios
+CuT = CuDTWR + CuDTWG + CuDTWB
+ZnT = ZnDTWR + ZnDTWG + ZnDTWB
+PbT = PbDTWR + PbDTWG + PbDTWB
+MxT = MDTWR + MDTWG + MDTWB
+CoT = CDTWR + CDTWG + CDTWB
+WoT = WDTWR + WDTWG + WDTWB
+DoT = DDTWR + DDTWG + DDTWB
+NoT = NDTWR + NDTWG + NDTWB
+LoT = LDTWR + LDTWG + LDTWB
+SoT = SDTWR + SDTWG + SDTWB
+AoT = ADTWR + ADTWG + ADTWB
+
+
+CuTr = CuDTWR./CuT
+ZnTr = ZnDTWR./ZnT
+PbTr = PbDTWR./PbT
+MxTr = MDTWR./MxT
+CoTr = CDTWR./CoT
+WoTr = WDTWR./WoT
+DoTr = DDTWR./DoT
+NoTr = NDTWR./NoT
+LoTr = LDTWR./LoT
+SoTr = SDTWR./SoT
+AoTr = ADTWR./AoT
+
+CuTg = CuDTWG./CuT
+ZnTg = ZnDTWG./ZnT
+PbTg = PbDTWG./PbT
+MxTg = MDTWG./MxT
+CoTg = CDTWG./CoT
+WoTg = WDTWG./WoT
+DoTg = DDTWG./DoT
+NoTg = NDTWG./NoT
+LoTg = LDTWG./LoT
+SoTg = SDTWG./SoT
+AoTg = ADTWG./AoT
+
+CuTb = CuDTWB./CuT
+ZnTb = ZnDTWB./ZnT
+PbTb = PbDTWB./PbT
+MxTb = MDTWB./MxT
+CoTb = CDTWB./CoT
+WoTb = WDTWB./WoT
+DoTb = DDTWB./DoT
+NoTb = NDTWB./NoT
+LoTb = LDTWB./LoT
+SoTb = SDTWB./SoT
+AoTb = ADTWB./AoT
+
+
+
+T1 = [CuDTWR(1,:) CuDTWG(1,:) CuDTWB(1,:); CuDTWR(2,:) CuDTWG(2,:) CuDTWB(2,:); CuDTWR(3,:) CuDTWG(3,:) CuDTWB(3,:); CuDTWR(4,:) CuDTWG(4,:) CuDTWB(4,:); CuDTWR(5,:) CuDTWG(5,:) CuDTWB(5,:); CuDTWR(6,:) CuDTWG(6,:) CuDTWB(6,:);CuDTWR(7,:) CuDTWG(7,:) CuDTWB(7,:); CuDTWR(8,:) CuDTWG(8,:) CuDTWB(8,:)];
+T2 = [ZnDTWR(1,:) ZnDTWG(1,:) ZnDTWB(1,:); ZnDTWR(2,:) ZnDTWG(2,:) ZnDTWB(2,:); ZnDTWR(3,:) ZnDTWG(3,:) ZnDTWB(3,:); ZnDTWR(4,:) ZnDTWG(4,:) ZnDTWB(4,:); ZnDTWR(5,:) ZnDTWG(5,:) ZnDTWB(5,:); ZnDTWR(6,:) ZnDTWG(6,:) ZnDTWB(6,:);ZnDTWR(7,:) ZnDTWG(7,:) ZnDTWB(7,:); ZnDTWR(8,:) ZnDTWG(8,:) ZnDTWB(8,:)];
+T3 = [PbDTWR(1,:) PbDTWG(1,:) PbDTWB(1,:); PbDTWR(2,:) PbDTWG(2,:) PbDTWB(2,:); PbDTWR(3,:) PbDTWG(3,:) PbDTWB(3,:); PbDTWR(4,:) PbDTWG(4,:) PbDTWB(4,:); PbDTWR(5,:) PbDTWG(5,:) PbDTWB(5,:); PbDTWR(6,:) PbDTWG(6,:) PbDTWB(6,:);PbDTWR(7,:) PbDTWG(7,:) PbDTWB(7,:); PbDTWR(8,:) PbDTWG(8,:) PbDTWB(8,:)];
+T4 = [MDTWR(1,:) MDTWG(1,:) MDTWB(1,:); MDTWR(2,:) MDTWG(2,:) MDTWB(2,:); MDTWR(3,:) MDTWG(3,:) MDTWB(3,:); MDTWR(4,:) MDTWG(4,:) MDTWB(4,:); MDTWR(5,:) MDTWG(5,:) MDTWB(5,:); MDTWR(6,:) MDTWG(6,:) MDTWB(6,:);MDTWR(7,:) MDTWG(7,:) MDTWB(7,:); MDTWR(8,:) MDTWG(8,:) MDTWB(8,:)];
+T5 = [CDTWR(1,:) CDTWG(1,:) CDTWB(1,:); CDTWR(2,:) CDTWG(2,:) CDTWB(2,:); CDTWR(3,:) CDTWG(3,:) CDTWB(3,:); CDTWR(4,:) CDTWG(4,:) CDTWB(4,:); CDTWR(5,:) CDTWG(5,:) CDTWB(5,:); CDTWR(6,:) CDTWG(6,:) CDTWB(6,:);CDTWR(7,:) CDTWG(7,:) CDTWB(7,:); CDTWR(8,:) CDTWG(8,:) CDTWB(8,:)];
+T6 = [WDTWR(1,:) WDTWG(1,:) WDTWB(1,:); WDTWR(2,:) WDTWG(2,:) WDTWB(2,:); WDTWR(3,:) WDTWG(3,:) WDTWB(3,:); WDTWR(4,:) WDTWG(4,:) WDTWB(4,:); WDTWR(5,:) WDTWG(5,:) WDTWB(5,:); WDTWR(6,:) WDTWG(6,:) WDTWB(6,:); WDTWR(7,:) WDTWG(7,:) WDTWB(7,:); WDTWR(8,:) WDTWG(8,:) WDTWB(8,:)];
+T7 = [DDTWR(1,:) DDTWG(1,:) DDTWB(1,:); DDTWR(2,:) DDTWG(2,:) DDTWB(2,:); DDTWR(3,:) DDTWG(3,:) DDTWB(3,:); DDTWR(4,:) DDTWG(4,:) DDTWB(4,:); DDTWR(5,:) DDTWG(5,:) DDTWB(5,:); DDTWR(6,:) DDTWG(6,:) DDTWB(6,:); DDTWR(7,:) DDTWG(7,:) DDTWB(7,:); DDTWR(8,:) DDTWG(8,:) DDTWB(8,:)];
+T8 = [NDTWR(1,:) NDTWG(1,:) NDTWB(1,:); NDTWR(2,:) NDTWG(2,:) NDTWB(2,:); NDTWR(3,:) NDTWG(3,:) NDTWB(3,:); NDTWR(4,:) NDTWG(4,:) NDTWB(4,:); NDTWR(5,:) NDTWG(5,:) NDTWB(5,:); NDTWR(6,:) NDTWG(6,:) NDTWB(6,:); NDTWR(7,:) NDTWG(7,:) NDTWB(7,:); NDTWR(8,:) NDTWG(8,:) NDTWB(8,:)];
+T9 = [LDTWR(1,:) LDTWG(1,:) LDTWB(1,:); LDTWR(2,:) LDTWG(2,:) LDTWB(2,:); LDTWR(3,:) LDTWG(3,:) LDTWB(3,:); LDTWR(4,:) LDTWG(4,:) LDTWB(4,:); LDTWR(5,:) LDTWG(5,:) LDTWB(5,:); LDTWR(6,:) LDTWG(6,:) LDTWB(6,:); LDTWR(7,:) LDTWG(7,:) LDTWB(7,:); LDTWR(8,:) LDTWG(8,:) LDTWB(8,:)];
+T10 = [SDTWR(1,:) SDTWG(1,:) SDTWB(1,:); SDTWR(2,:) SDTWG(2,:) SDTWB(2,:); SDTWR(3,:) SDTWG(3,:) SDTWB(3,:); SDTWR(4,:) SDTWG(4,:) SDTWB(4,:); SDTWR(5,:) SDTWG(5,:) SDTWB(5,:); SDTWR(6,:) SDTWG(6,:) SDTWB(6,:); SDTWR(7,:) SDTWG(7,:) SDTWB(7,:); SDTWR(8,:) SDTWG(8,:) SDTWB(8,:)];
+T11 = [ADTWR(1,:) ADTWG(1,:) ADTWB(1,:); ADTWR(2,:) ADTWG(2,:) ADTWB(2,:); ADTWR(3,:) ADTWG(3,:) ADTWB(3,:); ADTWR(4,:) ADTWG(4,:) ADTWB(4,:); ADTWR(5,:) ADTWG(5,:) ADTWB(5,:); ADTWR(6,:) ADTWG(6,:) ADTWB(6,:); ADTWR(7,:) ADTWG(7,:) ADTWB(7,:); ADTWR(8,:) ADTWG(8,:) ADTWB(8,:)];
+
+tiledlayout(6,2)
+% Top bar graph
+ax1 = nexttile;
+b1 = bar(ax1,T1)
+b1(1).FaceColor = [0.6350 0.0780 0.1840];
+b1(2).FaceColor = [0.4660 0.6740 0.1880];
+b1(3).FaceColor = [[0 0.4470 0.7410]];
+ylabel('Copper');
+axis([0 9 0 0.5])
+ax2 = nexttile;
+b2 = bar(ax2,T2)
+b2(1).FaceColor = [0.6350 0.0780 0.1840];
+b2(2).FaceColor = [0.4660 0.6740 0.1880];
+b2(3).FaceColor = [[0 0.4470 0.7410]];
+ylabel('Zinc');
+axis([0 9 0 0.5])
+ax3 = nexttile;
+b3 = bar(ax3,T3)
+b3(1).FaceColor = [0.6350 0.0780 0.1840];
+b3(2).FaceColor = [0.4660 0.6740 0.1880];
+b3(3).FaceColor = [[0 0.4470 0.7410]];
+ylabel('Lead');
+axis([0 9 0 0.5])
+ax4 = nexttile;
+b4 = bar(ax4,T4)
+b4(1).FaceColor = [0.6350 0.0780 0.1840];
+b4(2).FaceColor = [0.4660 0.6740 0.1880];
+b4(3).FaceColor = [[0 0.4470 0.7410]];
+ylabel('Mix');
+axis([0 9 0 0.5])
+ax5 = nexttile;
+b5 = bar(ax5,T5)
+b5(1).FaceColor = [0.6350 0.0780 0.1840];
+b5(2).FaceColor = [0.4660 0.6740 0.1880];
+b5(3).FaceColor = [[0 0.4470 0.7410]];
+ylabel('Cont.');
+axis([0 9 0 0.5])
+ax6 = nexttile;
+b6 = bar(ax6,T6)
+b6(1).FaceColor = [0.6350 0.0780 0.1840];
+b6(2).FaceColor = [0.4660 0.6740 0.1880];
+b6(3).FaceColor = [[0 0.4470 0.7410]];
+ylabel('Wet');
+axis([0 9 0 0.5])
+ax7 = nexttile;
+b7 = bar(ax7,T7)
+b7(1).FaceColor = [0.6350 0.0780 0.1840];
+b7(2).FaceColor = [0.4660 0.6740 0.1880];
+b7(3).FaceColor = [[0 0.4470 0.7410]];
+ylabel('Dry');
+axis([0 9 0 0.5])
+ax8 = nexttile;
+b8 = bar(ax8,T8)
+b8(1).FaceColor = [0.6350 0.0780 0.1840];
+b8(2).FaceColor = [0.4660 0.6740 0.1880];
+b8(3).FaceColor = [[0 0.4470 0.7410]];
+ylabel('Nuts.');
+axis([0 9 0 0.5])
+ax9 = nexttile;
+b9 = bar(ax9,T9)
+b9(1).FaceColor = [0.6350 0.0780 0.1840];
+b9(2).FaceColor = [0.4660 0.6740 0.1880];
+b9(3).FaceColor = [[0 0.4470 0.7410]];
+ylabel('Long');
+axis([0 9 0 0.5])
+ax10 = nexttile;
+b10 = bar(ax10,T10)
+b10(1).FaceColor = [0.6350 0.0780 0.1840];
+b10(2).FaceColor = [0.4660 0.6740 0.1880];
+b10(3).FaceColor = [[0 0.4470 0.7410]];
+ylabel('Short');
+axis([0 9 0 0.5])
+ax11 = nexttile;
+b11 = bar(ax11,T11)
+b11(1).FaceColor = [0.6350 0.0780 0.1840];
+b11(2).FaceColor = [0.4660 0.6740 0.1880];
+b11(3).FaceColor = [[0 0.4470 0.7410]];
+ylabel('Dark');
+axis([0 9 0 0.5])

--- a/Ttest2.m
+++ b/Ttest2.m
@@ -1,0 +1,192 @@
+CMRvG = 0.147
+CMRvB = 0.148
+CMGvB = 0.153
+ 
+CSRvG = 0.190
+CSRvB = 0.163
+CSGvB = 0.200
+
+x = [0 1 2 3 4 5 6 7];
+
+CuRvG = [0.192 0.202 0.139 0.131 0.145 0.296 0.177 0.162];
+CuGvB = [0.189 0.196 0.148 0.146 0.158 0.362 0.209 0.193];
+CuRvB = [0.176 0.195 0.137 0.139 0.143 0.194 0.181 0.169];
+
+ZnRvG = [0.138 0.136 0.134 0.142 0.130 0.247 0.140 0.149];
+ZnGvB = [0.141 0.148 0.140 0.146 0.140 0.282 0.162 0.163];
+ZnRvB = [0.138 0.143 0.136 0.142 0.137 0.156 0.151 0.155];
+
+PbRvG = [0.145 0.229 0.134 0.209 0.147 0.218 0.201 0.136];
+PbGvB = [0.165 0.219 0.143 0.206 0.154 0.228 0.211 0.146];
+PbRvB = [0.159 0.202 0.134 0.198 0.151 0.151 0.194 0.139];
+
+MixRvG = [0.134 0.295 0.155 0.425 0.195 0.545 0.320 0.224];
+MixGvB = [0.141 0.288 0.152 0.418 0.206 0.676 0.370 0.266];
+MixRvB = [0.139 0.248 0.147 0.361 0.183 0.404 0.301 0.232];
+
+
+NuRvG = [0.148 0.154 0.156 0.152 0.152 0.281 0.152 0.154];
+NuGvB = [0.158 0.172 0.163 0.175 0.178 0.332 0.177 0.187];
+NuRvB = [0.149 0.165 0.157 0.170 0.175 0.182 0.173 0.170];
+
+DryRvG = [0.144 0.144 0.148 0.150 0.145 0.204 0.155 0.161];
+DryGvB = [0.148 0.148 0.152 0.151 0.138 0.204 0.155 0.170];
+DryRvB = [0.146 0.146 0.145 0.149 0.142 0.160 0.135 0.182];
+
+WetRvG = [0.149 0.149 0.165 0.147 0.144 0.258 0.160 0.157];
+WetGvB = [0.151 0.151 0.172 0.156 0.154 0.287 0.176 0.178];
+WetRvB = [0.146 0.146 0.171 0.151 0.150 0.167 0.170 0.172];
+
+
+ShRvG = [0.153 0.153 0.150 0.158 0.155 0.248 0.176 0.145];
+ShGvB = [0.172 0.172 0.172 0.183 0.181 0.305 0.203 0.165];
+ShRvB = [0.168 0.168 0.167 0.176 0.172 0.158 0.196 0.159];
+
+LgRvG = [0.162 0.162 0.184 0.149 0.167 0.288 0.202 0.186];
+LgGvB = [0.172 0.172 0.187 0.159 0.173 0.306 0.197 0.185];
+LgRvB = [0.164 0.164 0.181 0.151 0.162 0.194 0.185 0.176];
+
+DkRvG = [0.160 0.160 0.142 0.174 0.147 0.281 0.151 0.150];
+DkGvB = [0.194 0.194 0.179 0.210 0.188 0.349 0.192 0.191];
+DkRvB = [0.183 0.183 0.168 0.201 0.178 0.186 0.179 0.185];
+
+
+figure;
+plot(x,CuRvG,'LineWidth',2);
+hold on
+plot(x,ZnRvG,'LineWidth',2);
+plot(x,PbRvG,'LineWidth',2);
+plot(x,MixRvG,'LineWidth',2);
+yline(CMRvG,'k','LineWidth',2);
+yline(CSRvG,'k--','LineWidth',2);
+legend('Copper','Zinc','Lead', 'Mix','Mean','3\sigma');
+set(gca,'fontname','arial','fontsize',18,'fontweight','bold');
+title('T-test Comparison of Metals (RvG)');
+xlabel('Time(days)');
+ylabel('t-value');
+axis([0 7 0.1 .7]);
+hold off
+
+figure;
+plot(x,CuGvB,'LineWidth',2);
+hold on
+plot(x,ZnGvB,'LineWidth',2);
+plot(x,PbGvB,'LineWidth',2);
+plot(x,MixGvB,'LineWidth',2);
+yline(CMGvB,'k','LineWidth',2);
+yline(CSGvB,'k--','LineWidth',2);
+legend('Copper','Zinc','Lead', 'Mix','Mean','3\sigma');
+set(gca,'fontname','arial','fontsize',18,'fontweight','bold');
+title('T-test Comparison of Metals (GvB)');
+xlabel('Time(days)');
+ylabel('t-value');
+axis([0 7 0.1 .7]);
+hold off
+
+figure;
+plot(x,CuRvB,'LineWidth',2);
+hold on
+plot(x,ZnRvB,'LineWidth',2);
+plot(x,PbRvB,'LineWidth',2);
+plot(x,MixRvB,'LineWidth',2);
+yline(CMRvB,'k','LineWidth',2);
+yline(CSRvB,'k--','LineWidth',2);
+legend('Copper','Zinc','Lead', 'Mix','Mean','3\sigma');
+set(gca,'fontname','arial','fontsize',18,'fontweight','bold');
+title('T-test Comparison of Metals (RvB)');
+xlabel('Time(days)');
+ylabel('t-value');
+axis([0 7 0.1 .7]);
+hold off
+
+figure;
+plot(x,WetRvG,'LineWidth',2);
+hold on
+plot(x,DryRvG,'LineWidth',2);
+plot(x,NuRvG,'LineWidth',2);
+yline(CMRvG,'k','LineWidth',2);
+yline(CSRvG,'k--','LineWidth',2);
+legend('Wet','Dry','Nutrients','Mean','3\sigma');
+set(gca,'fontname','arial','fontsize',18,'fontweight','bold');
+title('T-test Environmental Stressors (RvG)');
+xlabel('Time(days)');
+ylabel('t-value');
+axis([0 7 0.1 .7]);
+hold off
+
+figure;
+plot(x,WetGvB,'LineWidth',2);
+hold on
+plot(x,DryGvB,'LineWidth',2);
+plot(x,NuGvB,'LineWidth',2);
+yline(CMGvB,'k','LineWidth',2);
+yline(CSGvB,'k--','LineWidth',2);
+legend('Wet','Dry','Nutrients','Mean','3\sigma');
+set(gca,'fontname','arial','fontsize',18,'fontweight','bold');
+title('T-test Environmental Stressors (GvB)');
+xlabel('Time(days)');
+ylabel('t-value');
+axis([0 7 0.1 .7]);
+hold off
+
+figure;
+plot(x,WetRvB,'LineWidth',2);
+hold on
+plot(x,DryRvB,'LineWidth',2);
+plot(x,NuRvB,'LineWidth',2);
+yline(CMRvB,'k','LineWidth',2);
+yline(CSRvB,'k--','LineWidth',2);
+legend('Wet','Dry','Nutrients','Mean','3\sigma');
+set(gca,'fontname','arial','fontsize',18,'fontweight','bold');
+title('T-test Environmental Stressors (RvB)');
+xlabel('Time(days)');
+ylabel('t-value');
+axis([0 7 0.1 .7]);
+hold off
+
+figure;
+plot(x,LgRvG,'LineWidth',2);
+hold on
+plot(x,ShRvG,'LineWidth',2);
+plot(x,DkRvG,'LineWidth',2);
+yline(CMRvG,'k','LineWidth',2);
+yline(CSRvG,'k--','LineWidth',2);
+legend('Long','Short','Dark','Mean','3\sigma');
+set(gca,'fontname','arial','fontsize',18,'fontweight','bold');
+title('T-test Comparison of Photoperiod (RvG)');
+xlabel('Time(days)');
+ylabel('t-value');
+axis([0 7 0.1 .7]);
+hold off
+
+figure;
+plot(x,LgGvB,'LineWidth',2);
+hold on
+plot(x,ShGvB,'LineWidth',2);
+plot(x,DkGvB,'LineWidth',2);
+yline(CMGvB,'k','LineWidth',2);
+yline(CSGvB,'k--','LineWidth',2);
+legend('Long','Short','Dark','Mean','3\sigma');
+set(gca,'fontname','arial','fontsize',18,'fontweight','bold');
+title('T-test Comparison of Photoperiod (GvB)');
+xlabel('Time(days)');
+ylabel('t-value');
+axis([0 7 0.1 .7]);
+hold off
+
+figure;
+plot(x,LgRvB,'LineWidth',2);
+hold on
+plot(x,ShRvB,'LineWidth',2);
+plot(x,DkRvB,'LineWidth',2);
+yline(CMRvB,'k','LineWidth',2);
+yline(CSRvB,'k--','LineWidth',2);
+legend('Long','Short','Dark','Mean','3\sigma');
+set(gca,'fontname','arial','fontsize',18,'fontweight','bold');
+title('T-test Comparison of Photoperiod (RvB)');
+xlabel('Time(days)');
+ylabel('t-value');
+axis([0 7 0.1 .7]);
+hold off
+
+

--- a/Welch.m
+++ b/Welch.m
@@ -1,0 +1,16 @@
+function ret = Welch(a,b,c,d)
+
+%a = mean of control (specific day)
+%b = mean of trial (specific day)
+%c = variance of control
+%d = variance of trial
+
+x1 = 10;
+x2 = 10;
+
+tab = abs((a-b)./sqrt((c./x1)+(d./x2)));
+dfab = ((c./x1)+(d./x2)).^2./(((c./x1).^2./(x1-1))+((d./x2).^2./(x2-1)));
+tcritab = tinv(.95,dfab);
+TF = gt(tab,tcritab)
+
+ret = [tab dfab tcritab TF];

--- a/batchB.m
+++ b/batchB.m
@@ -1,0 +1,11 @@
+function blue = batchB(n)
+
+arrayB = zeros(256,length(n.Files));
+  for i = 1:length(n.Files)
+     RGB = readimage(n,i);
+     B = imhist(RGB(:,:,3))
+     meanB = B/sum(B);
+     arrayB(:,i) = meanB;
+  end
+  blue = arrayB
+end

--- a/batchG.m
+++ b/batchG.m
@@ -1,0 +1,11 @@
+function green = batchG(n)
+
+arrayG = zeros(256,length(n.Files));
+  for i = 1:length(n.Files)
+     RGB = readimage(n,i);
+     G = imhist(RGB(:,:,2)); 
+     meanG = G/sum(G);
+     arrayG(:,i) = meanG;
+  end
+ green = arrayG
+end

--- a/batchMB.m
+++ b/batchMB.m
@@ -1,0 +1,22 @@
+%MASTER is for the control only!  mean of total curves and std
+function meanSTDB = batchMB(n)
+
+arrayR = zeros(256,length(n.Files));
+  for i = 1:length(n.Files)
+     RGB = readimage(n,i);
+     B = imhist(RGB(:,:,3));
+     meanB = B./sum(B);
+     arrayB(:,i) = meanB;
+  end
+k1=length(arrayB);
+MmeanB = mean(arrayB,2);
+run = arrayB - MmeanB
+%run2 = sum((arrayR - MmeanR),2)
+run3 = run.^2
+MvarB = sum(run3,2)./(k1-1);
+MstdB = sqrt(MvarB);
+MstdB2 = MmeanB + (2.*MstdB)
+MstdB3 = MmeanB + (3.*MstdB)
+meanSTDB = [MmeanB MstdB2 MstdB3];
+end
+

--- a/batchMG.m
+++ b/batchMG.m
@@ -1,0 +1,22 @@
+%MASTER is for the control only!  mean of total curves and std
+function meanSTDG = batchMG(n)
+
+arrayR = zeros(256,length(n.Files));
+  for i = 1:length(n.Files)
+     RGB = readimage(n,i);
+     G = imhist(RGB(:,:,2));
+     meanG = G/sum(G);
+     arrayG(:,i) = meanG;
+  end
+k1=length(arrayG);
+MmeanG = mean(arrayG,2);;
+run = arrayG - MmeanG
+%run2 = sum((arrayR - MmeanR),2)
+run3 = run.^2
+MvarG = sum(run3,2)./(k1-1);
+MstdG = sqrt(MvarG);
+MstdG2 = MmeanG + (2.*MstdG)
+MstdG3 = MmeanG + (3.*MstdG)
+meanSTDG = [MmeanG MstdG2 MstdG3];
+end
+

--- a/batchMR.m
+++ b/batchMR.m
@@ -1,0 +1,21 @@
+%MASTER is for the control only!  mean of total curves and std
+function meanSTDR = batchMR(n)
+
+arrayR = zeros(256,length(n.Files));
+  for i = 1:length(n.Files)
+     RGB = readimage(n,i);
+     R = imhist(RGB(:,:,1));
+     meanR = R/sum(R);
+     arrayR(:,i) = meanR;
+  end
+k1=length(arrayR);
+MmeanR = mean(arrayR,2);
+run = arrayR - MmeanR
+%run2 = sum((arrayR - MmeanR),2)
+run3 = run.^2
+MvarR = sum(run3,2)./(k1-1);
+MstdR = sqrt(MvarR);
+MstdR2 = MmeanR + (2.*MstdR)
+MstdR3 = MmeanR + (3.*MstdR)
+meanSTDR = [MmeanR MstdR2 MstdR3];
+end

--- a/batchR.m
+++ b/batchR.m
@@ -1,0 +1,11 @@
+function red = batchR(n)
+
+arrayR = zeros(256,length(n.Files));
+  for i = 1:length(n.Files)
+     RGB = readimage(n,i);
+     R = imhist(RGB(:,:,1));
+     meanR = R/sum(R);
+     arrayR(:,i) = meanR;
+  end
+  red = arrayR
+end

--- a/diffR2.m
+++ b/diffR2.m
@@ -1,0 +1,16 @@
+function red = diffR2(n,j)
+
+len = size(n);
+lenT = len(1,2);
+arrayRt = zeros(lenT,256);
+  for i = 1:length(n)
+     compare = (1 - (sum(min(j(:,1),n))));
+  end
+k = length(compare);
+MmeanR = sum(compare)/k;
+MvarR = sum((compare - MmeanR).^2)./(k-1);
+MstdR = sqrt(MvarR);
+MstdR2 = MmeanR + (2.*MstdR')
+MstdR3 = MmeanR + (3.*MstdR')
+red = [MmeanR MstdR2 MstdR3 MstdR MvarR];
+end

--- a/dtwR.m
+++ b/dtwR.m
@@ -1,0 +1,22 @@
+function red = dtwR(i,j)
+
+DTW1 = dtw(i,j(:,1));
+DTW2 = dtw(i,j(:,2));
+DTW3 = dtw(i,j(:,3));
+DTW4 = dtw(i,j(:,4));
+DTW5 = dtw(i,j(:,5));
+DTW6 = dtw(i,j(:,6));
+DTW7 = dtw(i,j(:,7));
+DTW8 = dtw(i,j(:,8));
+DTW9 = dtw(i,j(:,9));
+DTW10 = dtw(i,j(:,10));
+
+dtwTOT = [DTW1 DTW2 DTW3 DTW4 DTW5 DTW6 DTW7 DTW8 DTW9 DTW10];
+meandtw = sum(dtwTOT)/10;
+vardtw = sum((dtwTOT - meandtw).^2)./(9);
+stddtw = sqrt(vardtw);
+std2dtw = meandtw + (2.*stddtw);
+std3dtw = meandtw + (3.*stddtw);
+
+red = [meandtw std2dtw std3dtw stddtw];
+end

--- a/one.m
+++ b/one.m
@@ -1,0 +1,63 @@
+function one = one(x,y); 
+%C = cell(length(x));
+%C = cell(length(x),length(y));
+M1 = min(size(x));
+M2 = min(size(y));
+
+C = cell(M1,M2);
+
+for m = 1:1:M1
+    for j = 1:1:M2
+        C{m,j} = dtw(x(:,m),y(:,j));
+    end
+end
+%one = C
+k1=length(C)
+ABC = cell2mat(C);
+meanR = mean(ABC,2);
+meanC = mean(meanR);
+run = meanR - meanC
+%run2 = sum((arrayR - MmeanR),2)
+run3 = run.^2
+MvarR = sum(run3)./(k1-1);
+MstdR = sqrt(MvarR);
+MstdR2 = meanC + (2.*MstdR)
+MstdR3 = meanC + (3.*MstdR)
+MS2 = 2.*MstdR
+MS3 = 3.*MstdR
+one = [meanC MS2 MS3 MstdR MvarR];
+
+
+%take mean of each row, then mean of the column and std. 
+%n = MasterCS
+%arrayR = zeros(256,length(n.Files));
+%  for i = 1:length(n.Files)
+%     RGB = readimage(n,i);
+%     R = imhist(RGB(:,:,1));
+%     meanR = R/sum(R);
+%     arrayR(:,i) = meanR;
+%  end
+
+%x = [Cu0R(:,1) Cu0R(:,2)]
+%y = [arrayR(:,1) arrayR(:,2)]
+%m = 1:1:(min(size(x)));
+%k = dtw(x(:,2),y(:,2));%
+
+%C = cell(length(x),length(y));
+%for m = 1:1:(min(size(x)));
+%    C{m,j} = dtw(x(:,m),y(:,j));
+%end
+
+
+
+%A = [dtw(x(:,1),y(:,1)) dtw(x(:,2),y(:,1)); dtw(x(:,1),y(:,2)) dtw(x(:,2),y(:,2))];
+    
+%x = [2 3 4 5 6 7 2 3];
+%y = [4 3 5 2 3 4 7 2];
+
+%t = x.*y';
+%i = 1:1:length(x);
+%j = 1:1:length(y);
+%t3 = x(:,i)*y(:,j);
+%t2 = corr2(x(:,i),y(:,j));
+%size = size(x)

--- a/sumR.m
+++ b/sumR.m
@@ -1,0 +1,14 @@
+function red = sumR(n)
+
+k1=length(n);
+MmeanR = sum(n)/k1;
+run = n - MmeanR
+%run2 = sum((arrayR - MmeanR),2)
+run3 = run.^2
+MvarR = sum(run3,2)./(k1-1);
+MstdR = sqrt(MvarR);
+MstdR2 = MmeanR + (2.*MstdR)
+MstdR3 = MmeanR + (3.*MstdR)
+red = [MmeanR MstdR2 MstdR3 MstdR];
+end
+


### PR DESCRIPTION
These files correspond to images collected with the CoCoBi at a Gain of 5 using Both Lasers (Green and UV). These files are mostly interchangeable with different groups of images save for the folder access.  When using them it is important to retain functions for batch processing, density difference, and dtw. The mean method was not included due to it being less sensitive to contaminant detection.  Both density difference and dtw can be used on singular images, but batch processing was a major part of the presented work. 